### PR TITLE
fix: sort endpoints by service name

### DIFF
--- a/Endpoints.json
+++ b/Endpoints.json
@@ -1,1823 +1,1820 @@
-{
-    "@odata.context": "https://graph.microsoft.com/beta/$metadata#servicePrincipals('appId%3D0000000a-0000-0000-c000-000000000000')/endpoints",
-    "value": [
-        {
-            "id": "86ae72e3-fb48-4bbb-bccf-f6f5813cf8e5",
-            "deletedDateTime": null,
-            "capability": "MobileAccessServiceAgents",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MobileAccessServiceAgents",
-            "uri": "https://agents.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/MobileAccess/MobileAccessService",
-            "providerResourceId": "e7296ea6-dc65-44f4-9c95-8293cbb00515"
-        },
-        {
-            "id": "7859d3ac-fb85-49c3-87a3-5b4b470de506",
-            "deletedDateTime": null,
-            "capability": "TotalNumberOfEndpoints",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "TotalNumberOfEndpoints",
-            "uri": "177",
-            "providerResourceId": "0c101feb-b912-4e7a-9e4b-1d05773cd4d9"
-        },
-        {
-            "id": "8b945e3a-ae10-42ad-89b3-5e2bb6c12eba",
-            "deletedDateTime": null,
-            "capability": "AndroidDeviceGatewayCertificateService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AndroidDeviceGatewayCertificateService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/PassThroughRoutingService/AndroidSync/AndroidDeviceGatewayCertificateService",
-            "providerResourceId": "95dbdfb0-2f24-4b52-bd4a-89781cabdaa1"
-        },
-        {
-            "id": "b735eb0e-4777-47a4-821e-44216305885f",
-            "deletedDateTime": null,
-            "capability": "ICSGraphService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ICSGraphService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ICS/ICSGraphService",
-            "providerResourceId": "c09d8fcc-5d43-4d9e-a199-40ff3238c2c7"
-        },
-        {
-            "id": "e75296e7-4b3b-451f-95f6-5bf43a4a64ca",
-            "deletedDateTime": null,
-            "capability": "RAODJPlusFEGatewayService_FEF",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "RAODJPlusFEGatewayService_FEF",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RAODJPlus/StatelessODJService",
-            "providerResourceId": "e584e573-ed1a-4e62-8656-39fe35ee72a5"
-        },
-        {
-            "id": "7bdfc279-9973-48cd-965f-a18e9aff2c70",
-            "deletedDateTime": null,
-            "capability": "IWService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "IWService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/IWService/StatelessIWService",
-            "providerResourceId": "38dcc0bd-bd30-4d11-b3ef-628bc0489280"
-        },
-        {
-            "id": "5c17c848-605f-4935-a674-5a3be1b444cf",
-            "deletedDateTime": null,
-            "capability": "DiagnosticService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DiagnosticService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DiagnosticService/StatelessDiagnosticService",
-            "providerResourceId": "1faf959c-a9ed-4d9f-ae64-75b655f287ea"
-        },
-        {
-            "id": "9f6db3d2-4bef-45bd-be4d-7da839c3e840",
-            "deletedDateTime": null,
-            "capability": "DeviceProvisioningAdminService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceProvisioningAdminService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Dep/DeviceProvisioningAdminService",
-            "providerResourceId": "caf4b68f-793d-457a-8c21-e5065ecbb1c4"
-        },
-        {
-            "id": "e07aff4a-e993-475e-8a1c-d744f49d7d54",
-            "deletedDateTime": null,
-            "capability": "GnTGraphService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "GnTGraphService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GnT/GnTGraphService",
-            "providerResourceId": "d7f0d9f5-c886-47f3-a0f8-005b6f64957c"
-        },
-        {
-            "id": "09a1cd56-9b08-4d65-a207-0a42f4cf191a",
-            "deletedDateTime": null,
-            "capability": "ReportingFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ReportingFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ReportingService/StatelessReportingFEService",
-            "providerResourceId": "0a91a93e-bb84-49d0-a1d6-11f4bd47f262"
-        },
-        {
-            "id": "76e9b656-3213-4e30-b81d-7d8fc5473253",
-            "deletedDateTime": null,
-            "capability": "ReportingExperienceService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ReportingExperienceService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ReportingService/ReportingExperienceService",
-            "providerResourceId": "fddef275-3cd0-474d-af6d-9c7f808d92fa"
-        },
-        {
-            "id": "3d848e36-d93e-4f5e-b312-4694a4195c9b",
-            "deletedDateTime": null,
-            "capability": "MultiDevicePivotService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MultiDevicePivotService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Pivot/MultiDevicePivotService",
-            "providerResourceId": "c6d3350d-2ae6-4043-82e8-5d26bbdceff3"
-        },
-        {
-            "id": "f96dbfcc-8749-44ef-b6c4-67a826f85f70",
-            "deletedDateTime": null,
-            "capability": "AospProvisioningService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AospProvisioningService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/PassThroughRoutingService/AndroidSpecialized/AospProvisioningService",
-            "providerResourceId": "c6195456-dad1-467f-aba7-a55095986e72"
-        },
-        {
-            "id": "4cdd8686-b1df-4344-af55-666d6724405b",
-            "deletedDateTime": null,
-            "capability": "AuthenticatedIOSEnrollmentService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AuthenticatedIOSEnrollmentService",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessIOSEnrollmentService",
-            "providerResourceId": "fcdfe381-bc43-42a5-bff6-e5151f2e996e"
-        },
-        {
-            "id": "7efed656-0074-403b-b686-5489a0bb1b43",
-            "deletedDateTime": null,
-            "capability": "DataInfraPartnerService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DataInfraPartnerService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DataInfra/PartnerService",
-            "providerResourceId": "b6bdb30a-010a-4ee9-a36d-ee8adb1793eb"
-        },
-        {
-            "id": "716efdc6-d231-4684-bb99-8caf9d1c9245",
-            "deletedDateTime": null,
-            "capability": "AgentEnrollmentRenewal",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AgentEnrollmentRenewal",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService",
-            "providerResourceId": "f6455ac6-9993-47ff-b7a5-2e9961def720"
-        },
-        {
-            "id": "0e92432d-c8fd-4bd0-924a-e5ea832f2241",
-            "deletedDateTime": null,
-            "capability": "OrganizationalMessagesService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "OrganizationalMessagesService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerIntegrations/OrganizationalMessagesService",
-            "providerResourceId": "7773652d-c93b-4401-97d9-6148a7081f1f"
-        },
-        {
-            "id": "4114e088-015f-443b-bfad-07f8709a8830",
-            "deletedDateTime": null,
-            "capability": "StatelessFERemoteAssistOnboardingService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessFERemoteAssistOnboardingService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RemoteAssistService/StatelessFERemoteAssistOnboardingService",
-            "providerResourceId": "7c5b4c52-1071-415c-9788-6dea959ac746"
-        },
-        {
-            "id": "50116e27-a9e9-456c-b857-3836e8b1519d",
-            "deletedDateTime": null,
-            "capability": "InventoryUpload",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "InventoryUpload",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceDataUpload/StatelessDeviceDataUploadService",
-            "providerResourceId": "83717582-3086-4367-9908-cea25067b09c"
-        },
-        {
-            "id": "a2daaf0d-f199-42a3-b1b4-58c06161e5f5",
-            "deletedDateTime": null,
-            "capability": "MAMAdminFEServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MAMAdminFEServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/MAMAdmin/MAMAdminFEService",
-            "providerResourceId": "8b1d74d7-aea4-44dd-95d7-3f29cf017426"
-        },
-        {
-            "id": "70a266a4-e851-40e3-9156-4bca23d06160",
-            "deletedDateTime": null,
-            "capability": "DeviceEnrollmentBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceEnrollmentBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessOnboardingService",
-            "providerResourceId": "03a9e901-bb3a-4ca5-9be3-06b5934c99a7"
-        },
-        {
-            "id": "a448df04-6b65-4bf8-a7d3-f2bf238729d1",
-            "deletedDateTime": null,
-            "capability": "DepFEServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DepFEServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/Dep/DepFEService",
-            "providerResourceId": "d5d29808-b339-4374-9227-185dace53db8"
-        },
-        {
-            "id": "56acfe19-7da6-466d-a73e-922b5bfffe4f",
-            "deletedDateTime": null,
-            "capability": "AppMetadataBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AppMetadataBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/AppLifecycle/StatelessAppMetadataFEService",
-            "providerResourceId": "714d24e0-a5cd-4d6f-a922-fdd51af68d63"
-        },
-        {
-            "id": "280592fa-a97e-4715-9a39-ad7206e4cd08",
-            "deletedDateTime": null,
-            "capability": "MobileAccessService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MobileAccessService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/MobileAccess/MobileAccessService",
-            "providerResourceId": "97846e7f-dedd-4af6-8f58-27cef7c03ad8"
-        },
-        {
-            "id": "d89f2841-ef69-4cbd-afdf-b9eacac172fd",
-            "deletedDateTime": null,
-            "capability": "SCCMConnectorService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SCCMConnectorService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Hybrid/StatelessConnectorService/",
-            "providerResourceId": "4d731aa8-7794-4b4b-ac8e-2b3bb6fb9f25"
-        },
-        {
-            "id": "231dedb0-9285-44e3-94d5-b79279e4a84e",
-            "deletedDateTime": null,
-            "capability": "CompanyTermFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "CompanyTermFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/CompanyTerms/StatelessCompanyTermFEService",
-            "providerResourceId": "f3f7111f-0670-499f-a5b6-a701bb903146"
-        },
-        {
-            "id": "76f0db8b-5c24-4138-89b2-bc7d616b4b75",
-            "deletedDateTime": null,
-            "capability": "DeviceEnrollment",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceEnrollment",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Wcs/StatelessOnboardingService",
-            "providerResourceId": "0d9c5414-fc5e-426d-9a2a-5f060d629a45"
-        },
-        {
-            "id": "bb57229f-4343-466c-aebb-2a3698ef4718",
-            "deletedDateTime": null,
-            "capability": "DeviceManagementIntentGatewayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceManagementIntentGatewayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceManagementIntent/DeviceManagementIntentService",
-            "providerResourceId": "958b645d-7661-4052-aec7-cdb55cf126d5"
-        },
-        {
-            "id": "5197130f-654d-498e-ba91-54d0d4fc919f",
-            "deletedDateTime": null,
-            "capability": "iOSSspEnrollmentPage",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "iOSSspEnrollmentPage",
-            "uri": "https://portal.manage.microsoft.com/enrollment/ios",
-            "providerResourceId": "9f010033-5beb-46fd-85a8-3f1b41a9dc69"
-        },
-        {
-            "id": "66d24ca5-3e63-4536-84fa-483ba3f1c225",
-            "deletedDateTime": null,
-            "capability": "ApplicationEnrollment",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ApplicationEnrollment",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService",
-            "providerResourceId": "fd6535fb-38cd-4735-960b-2eb3d3606605"
-        },
-        {
-            "id": "8ff8a8ee-6a9e-435c-bd27-188dd5a80360",
-            "deletedDateTime": null,
-            "capability": "SideCarGatewayServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SideCarGatewayServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/SideCar/StatelessSideCarGatewayService",
-            "providerResourceId": "de69b19a-0e10-4cc5-804e-c58ee52ce21a"
-        },
-        {
-            "id": "d30760a7-84d8-4e45-a11a-88b96751f9d6",
-            "deletedDateTime": null,
-            "capability": "ErrorEventWebService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ErrorEventWebService",
-            "uri": "http://msud01.manage.microsoft.com/ErrorEventWebService/ErrorEventWebService.svc",
-            "providerResourceId": "72cc42f9-e6ea-47b5-9f4e-041f10dd752d"
-        },
-        {
-            "id": "439c0216-2ca8-4764-b1a0-30cb59493ffd",
-            "deletedDateTime": null,
-            "capability": "Auditing",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "Auditing",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Auditing/StatelessAuditingFEService",
-            "providerResourceId": "d3ec4417-ee69-4f41-866a-0d130837047b"
-        },
-        {
-            "id": "c87556ef-7e42-407a-b26e-a52aa74e5a02",
-            "deletedDateTime": null,
-            "capability": "DeviceEnrollmentFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceEnrollmentFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceEnrollmentFE/StatelessDeviceEnrollmentFEService",
-            "providerResourceId": "3d028682-c3b2-483c-a802-a7702bb5fa51"
-        },
-        {
-            "id": "cfe33ee9-2b48-40d0-b63b-78ab12548234",
-            "deletedDateTime": null,
-            "capability": "EndpointProtection",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EndpointProtection",
-            "uri": "https://fef.msud01.manage.microsoft.com/IntuneDefenderServices/StatelessDefenderFEService",
-            "providerResourceId": "f3fe1d9e-55f4-41b3-a4b0-0d6a7b71ecab"
-        },
-        {
-            "id": "b4753d9e-5cec-435c-9370-4352d3a17d8b",
-            "deletedDateTime": null,
-            "capability": "ConfigManagerConnectorSTS",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ConfigManagerConnectorSTS",
-            "uri": "https://msud01.manage.microsoft.com/ConfigManagerConnectorSecurityTokenService/IWSTrust.svc",
-            "providerResourceId": "eba6869b-c2e5-4e43-8b75-c3426a5726b2"
-        },
-        {
-            "id": "fd8805b4-637e-4528-94a7-23d5a7177ecf",
-            "deletedDateTime": null,
-            "capability": "StatelessRemoteAssistService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessRemoteAssistService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RemoteAssistService/StatelessRemoteAssistService",
-            "providerResourceId": "8d89a596-cdfa-4476-acbb-e69ad093ee1a"
-        },
-        {
-            "id": "24d20696-8b74-4de8-bd3b-a05a65390aa1",
-            "deletedDateTime": null,
-            "capability": "IWServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "IWServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessIWService",
-            "providerResourceId": "9838a1c2-fcd1-46d8-ba46-e81364f3f9b9"
-        },
-        {
-            "id": "e39f06cf-64c1-405b-8723-90bc75a63f91",
-            "deletedDateTime": null,
-            "capability": "IWPortalAllEbooksPage",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "IWPortalAllEbooksPage",
-            "uri": "https://portal.manage.microsoft.com/ebooks",
-            "providerResourceId": "3d16a69e-5cea-4cf7-bdcc-36b92dfe99c8"
-        },
-        {
-            "id": "3dc582f7-c913-41b1-91f1-9009509c465b",
-            "deletedDateTime": null,
-            "capability": "UnAuthLocationSvc",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "UnAuthLocationSvc",
-            "uri": "https://manage.microsoft.com/UnAuthLocationService/UnAuthLocationService.svc",
-            "providerResourceId": "b63d0f3b-7e26-4b3d-9ca3-9466890a1e95"
-        },
-        {
-            "id": "42831abc-70a6-48e0-9622-1df49f31e70b",
-            "deletedDateTime": null,
-            "capability": "HttpsErrorEventWebService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "HttpsErrorEventWebService",
-            "uri": "https://msud01.manage.microsoft.com/ErrorEventWebService/ErrorEventWebService.svc",
-            "providerResourceId": "987df1c5-dc26-4d1c-acb4-cfb6bbd4ab51"
-        },
-        {
-            "id": "f1df8dab-39ff-4347-afba-62712625c47a",
-            "deletedDateTime": null,
-            "capability": "CustomerDataService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "CustomerDataService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Wcs/StatelessCustomerDataFEService",
-            "providerResourceId": "c1dd4d39-b85f-4265-9c87-6e4243e7ae79"
-        },
-        {
-            "id": "05156e06-864d-4edb-8aea-08e440709886",
-            "deletedDateTime": null,
-            "capability": "Region",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "Region",
-            "uri": "OC",
-            "providerResourceId": "31a2b6cc-7d5b-4b26-b2f8-7f3a9e4b2776"
-        },
-        {
-            "id": "244a8b2c-37db-4f46-bed3-11dd37fd52ed",
-            "deletedDateTime": null,
-            "capability": "SupportServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SupportServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessSupportService",
-            "providerResourceId": "89e6888e-1f1d-4ba6-9c50-112c31893144"
-        },
-        {
-            "id": "d24f6e76-6a75-48a9-b780-5802a081285f",
-            "deletedDateTime": null,
-            "capability": "TicketingFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "TicketingFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerIntegrations/TicketingFEService",
-            "providerResourceId": "7852851b-7a29-4370-a433-a0d1a9017b51"
-        },
-        {
-            "id": "384379cb-9aaa-4f00-a413-33d1c5b507bb",
-            "deletedDateTime": null,
-            "capability": "AndroidEnrollment",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AndroidEnrollment",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService/DeviceEnrollment.svc",
-            "providerResourceId": "85ae7b66-5278-438d-a072-c36c649c37bc"
-        },
-        {
-            "id": "80dbd81d-b962-4cd1-a2c0-b40f50ea175a",
-            "deletedDateTime": null,
-            "capability": "BrandingServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "BrandingServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessBrandingService",
-            "providerResourceId": "7623a913-0de5-4b4b-acf4-6ba3f17f82ee"
-        },
-        {
-            "id": "7ee4ca2f-fa1b-41ec-b465-248597eda3ce",
-            "deletedDateTime": null,
-            "capability": "AppMetadata",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AppMetadata",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AppLifecycle/StatelessAppMetadataFEService",
-            "providerResourceId": "74fe29b9-0806-43d5-b95b-663a886cfcea"
-        },
-        {
-            "id": "c0ad70a4-bece-4dc9-9625-08ec9c5499d3",
-            "deletedDateTime": null,
-            "capability": "StatelessAndroidSyncFEServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessAndroidSyncFEServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/AndroidSync/StatelessAndroidSyncFEService",
-            "providerResourceId": "114a73a4-7207-4ce2-b758-2ce1d0a44f0b"
-        },
-        {
-            "id": "1e2b822e-6ef2-4e49-83a7-0f7a3a90515a",
-            "deletedDateTime": null,
-            "capability": "SoftwareUpdateGatewayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SoftwareUpdateGatewayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Updates/SoftwareUpdateService",
-            "providerResourceId": "fee4c131-82ce-4b72-9eb7-451e86c2de9a"
-        },
-        {
-            "id": "5ae4c117-ed8b-4bb5-b38a-07108ee6eb5c",
-            "deletedDateTime": null,
-            "capability": "DataWarehouseBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DataWarehouseBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/ReportingService/DataWarehouseFEService",
-            "providerResourceId": "57bae6e4-84fd-4ca3-b840-9265bb27679f"
-        },
-        {
-            "id": "da14e929-f870-4378-a9a5-322f24cbb681",
-            "deletedDateTime": null,
-            "capability": "Device",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "Device",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceFE/StatelessDeviceFEService",
-            "providerResourceId": "04766c26-3988-42fd-b041-15812a697aff"
-        },
-        {
-            "id": "7ed61fce-6b6a-445e-b9b2-73b7ef76ba59",
-            "deletedDateTime": null,
-            "capability": "ServerAuthLocationServiceService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ServerAuthLocationServiceService",
-            "uri": "https://manage.microsoft.com/ServerAuthLocationService/ServerAuthLocationService.svc",
-            "providerResourceId": "be13c622-cf82-4335-bb37-b5e5587ea4d1"
-        },
-        {
-            "id": "b0bd588c-13a6-4cd7-9dff-33456e79d46f",
-            "deletedDateTime": null,
-            "capability": "ExchangeGatewayServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ExchangeGatewayServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessExchangeGatewayService",
-            "providerResourceId": "e7fc5e06-6c0b-4204-afb7-2cd885402715"
-        },
-        {
-            "id": "fffc740d-dc6d-4493-bab2-b9030f819320",
-            "deletedDateTime": null,
-            "capability": "ClientWebService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ClientWebService",
-            "uri": "https://msud01.manage.microsoft.com/ClientWebService/client.asmx/auth",
-            "providerResourceId": "3ad71fd9-6969-4426-8379-e7f2d7d6e1fc"
-        },
-        {
-            "id": "5bcc67d4-e898-4944-a279-fd59b3bc00c7",
-            "deletedDateTime": null,
-            "capability": "AdminExperienceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AdminExperienceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/AdminExperienceService",
-            "providerResourceId": "bdbf7aff-2170-4c46-9b63-11a9e184a92b"
-        },
-        {
-            "id": "da9a7580-c89c-4ea9-ae99-104acf271a91",
-            "deletedDateTime": null,
-            "capability": "AuditingBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AuditingBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessAuditingFEService",
-            "providerResourceId": "139eee2e-8519-46b9-b1d6-b45b02407a31"
-        },
-        {
-            "id": "fb77f78e-4a24-4903-826c-01a756430c7f",
-            "deletedDateTime": null,
-            "capability": "EnrollmentService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EnrollmentService",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService",
-            "providerResourceId": "a21081b8-daef-47fe-a761-f45e5fb68457"
-        },
-        {
-            "id": "4e403e8a-bcd8-4f73-ad12-97ae0a7b86ee",
-            "deletedDateTime": null,
-            "capability": "TokenRenewalService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "TokenRenewalService",
-            "uri": "https://fef.msud01.manage.microsoft.com/OAuth/StatelessOAuthService/OAuthProxy/",
-            "providerResourceId": "6fef5e1e-6448-4d8e-8ec7-98a97d68b5cc"
-        },
-        {
-            "id": "92f540b8-2561-416a-a6c3-bd2be8be4492",
-            "deletedDateTime": null,
-            "capability": "FencingSignalService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "FencingSignalService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Fencing/FencingSignalService",
-            "providerResourceId": "a1127a4b-cac0-4aa6-a8f2-da3629e5da35"
-        },
-        {
-            "id": "41a25532-4e94-410c-a232-1c7416984660",
-            "deletedDateTime": null,
-            "capability": "WebCPiOSCPEnrollmentPage",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "WebCPiOSCPEnrollmentPage",
-            "uri": "https://portal.manage.microsoft.com/enrollment/ios",
-            "providerResourceId": "3149e306-fa52-4e75-9c71-cbad3bcb59f1"
-        },
-        {
-            "id": "f88ce91e-a792-4c02-a200-dc21762d43e6",
-            "deletedDateTime": null,
-            "capability": "PkiConnectorFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "PkiConnectorFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/StatelessPkiConnectorService",
-            "providerResourceId": "8a29ed99-8710-4014-949f-ba0f8334e624"
-        },
-        {
-            "id": "fc88c6b6-f5af-4f9f-b2bd-45bcd78dd53d",
-            "deletedDateTime": null,
-            "capability": "GPAnalyticsService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "GPAnalyticsService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GPAnalytics/StatelessGPAnalyticsService",
-            "providerResourceId": "d97d928b-7f46-460f-8f0f-50ea183e2e5e"
-        },
-        {
-            "id": "968901c6-9885-4ab6-bc1a-478e39b1c60e",
-            "deletedDateTime": null,
-            "capability": "IWPortalSetActiveDevice",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "IWPortalSetActiveDevice",
-            "uri": "https://portal.manage.microsoft.com/enrollment/setActiveDevice",
-            "providerResourceId": "68676cbb-ab06-4af8-86c0-eccf3b6a389e"
-        },
-        {
-            "id": "10c91d10-14b2-4636-9968-8d332b2ef9f3",
-            "deletedDateTime": null,
-            "capability": "DeviceEnrollmentFEServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceEnrollmentFEServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/DeviceEnrollmentFE/StatelessDeviceEnrollmentFEService",
-            "providerResourceId": "7e8b6e09-e39f-4a53-a9d0-63bd85c14163"
-        },
-        {
-            "id": "a4cc03cc-2c12-4d17-a8db-03721b11721f",
-            "deletedDateTime": null,
-            "capability": "ExchangeGatewayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ExchangeGatewayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessExchangeGatewayService",
-            "providerResourceId": "32280f9d-a53f-42d3-ae22-47964e6ea075"
-        },
-        {
-            "id": "2e1a1b34-8db8-46af-8848-6707b5f1aa67",
-            "deletedDateTime": null,
-            "capability": "NotificationMessageTemplate",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "NotificationMessageTemplate",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Wcs/StatelessNotificationFEService",
-            "providerResourceId": "005e9a93-7ffe-4f1b-8e40-c6aeabeadb96"
-        },
-        {
-            "id": "02d72757-4640-456c-af71-0b79c0e94d2e",
-            "deletedDateTime": null,
-            "capability": "ApplicationCheckIn",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ApplicationCheckIn",
-            "uri": "https://fef.msud01.manage.microsoft.com/DeviceCheckin/SLDMService/ApplicationCheckIn",
-            "providerResourceId": "a6e1bb9e-0e43-4354-a332-13254bd7bee4"
-        },
-        {
-            "id": "d914f2f1-0e08-47f2-80a0-bdec5508ede7",
-            "deletedDateTime": null,
-            "capability": "DeviceManagementIntentGatewayServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceManagementIntentGatewayServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/DeviceManagementIntent/DeviceManagementIntentGatewayService",
-            "providerResourceId": "10afed53-f0f0-478e-a8a1-8080779a1f22"
-        },
-        {
-            "id": "fcf7d882-daae-41d1-8436-f7bcc13e1ba4",
-            "deletedDateTime": null,
-            "capability": "WebCPRoot",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "WebCPRoot",
-            "uri": "https://portal.manage.microsoft.com/",
-            "providerResourceId": "2f6c1fd5-0598-452e-862c-072f592ba105"
-        },
-        {
-            "id": "5dd033de-09cc-487c-86c6-f6fc29c30cdf",
-            "deletedDateTime": null,
-            "capability": "MSUName",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MSUName",
-            "uri": "MSUD01",
-            "providerResourceId": "5e1e7731-d7ab-4b77-9c4a-5584eafff9a6"
-        },
-        {
-            "id": "953ebcb2-0ac7-460e-b580-6c8118437b22",
-            "deletedDateTime": null,
-            "capability": "DeviceCheckin",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceCheckin",
-            "uri": "https://fef.msud01.manage.microsoft.com/DeviceCheckin",
-            "providerResourceId": "c225d0f8-b12a-4dac-9d59-12d94a4c45cb"
-        },
-        {
-            "id": "8cfe1c72-8497-4145-902f-00679aac8a31",
-            "deletedDateTime": null,
-            "capability": "RemoteAssistanceService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "RemoteAssistanceService",
-            "uri": "https://msud01.manage.microsoft.com/RemoteAssistanceService/RemoteAssistanceService.svc",
-            "providerResourceId": "cbe02f2d-3a33-42a2-a282-c984351a26d4"
-        },
-        {
-            "id": "08a674fd-20c2-4c5f-9d90-51cf287be354",
-            "deletedDateTime": null,
-            "capability": "MSU_URL",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MSU_URL",
-            "uri": "https://msud01.manage.microsoft.com/",
-            "providerResourceId": "e3b33764-5521-4280-9ad8-dd4f9e383dcc"
-        },
-        {
-            "id": "9d3e69dd-d68b-4775-9102-beb97694fdc4",
-            "deletedDateTime": null,
-            "capability": "ImportPFXGatewayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ImportPFXGatewayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/StatelessImportPFXService",
-            "providerResourceId": "f73d6f0e-2b8e-453f-81ff-d71a6c11bd75"
-        },
-        {
-            "id": "c73eb9bf-c889-46e3-91a6-d37e21c25544",
-            "deletedDateTime": null,
-            "capability": "CorporateDeviceEnrollment",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "CorporateDeviceEnrollment",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessCorporateDeviceEnrollmentService",
-            "providerResourceId": "6effb704-3195-45e5-ba1f-8e1dfd96f812"
-        },
-        {
-            "id": "d87d2546-8a17-475a-a42c-6cc4a42bde4c",
-            "deletedDateTime": null,
-            "capability": "LocationServiceService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "LocationServiceService",
-            "uri": "https://manage.microsoft.com/LocationService/LocationService.svc",
-            "providerResourceId": "595918ca-8858-4c07-81d8-aab64a4c2b9b"
-        },
-        {
-            "id": "44cf4134-ff43-431a-a15e-e45809413202",
-            "deletedDateTime": null,
-            "capability": "KeyService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "KeyService",
-            "uri": "https://manage.microsoft.com/KeyService/KeyServiceAgent.svc",
-            "providerResourceId": "ad367dab-a2f2-4549-a0f0-d45e39b6b0f3"
-        },
-        {
-            "id": "f9f245f4-3d46-4821-a99a-1cb2e3f8a24f",
-            "deletedDateTime": null,
-            "capability": "PCPortalRoot",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "PCPortalRoot",
-            "uri": "https://portal.manage.microsoft.com/",
-            "providerResourceId": "f9ce7849-73d4-4fa7-bacd-bf6e9ad4eb2e"
-        },
-        {
-            "id": "13b4b937-1bc2-42d4-bb3f-b5608dc41980",
-            "deletedDateTime": null,
-            "capability": "StatelessAndroidSyncFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessAndroidSyncFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AndroidSync/StatelessAndroidSyncFEService",
-            "providerResourceId": "4ef95124-cff8-4295-afa3-e4bb46ff8d3d"
-        },
-        {
-            "id": "103aa558-e126-48b7-a9ca-8971054e4911",
-            "deletedDateTime": null,
-            "capability": "DeviceCheckin_Canary",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceCheckin_Canary",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/DeviceCheckinRoutingService/DeviceCheckin",
-            "providerResourceId": "6c6494aa-af7c-45b3-aad6-212880045224"
-        },
-        {
-            "id": "e29c0891-4392-4cf1-8c5e-61400f5c893b",
-            "deletedDateTime": null,
-            "capability": "SCCMConnector",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SCCMConnector",
-            "uri": "https://msud01.manage.microsoft.com/SCCMConnectorService/SccmConnectorService.svc",
-            "providerResourceId": "e823ddc0-6382-485f-8a72-45ac8949c3fe"
-        },
-        {
-            "id": "e9d05135-4655-4ee6-884d-0b553b27351c",
-            "deletedDateTime": null,
-            "capability": "StatelessWIPReportFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessWIPReportFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/WIPReportServices/StatelessWIPReportFEService",
-            "providerResourceId": "583b327d-fd35-4663-b6fe-8412c150d582"
-        },
-        {
-            "id": "485c26d9-38b4-4b94-a5a4-ba79acfeef76",
-            "deletedDateTime": null,
-            "capability": "DocumentDistributionService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DocumentDistributionService",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessDocumentDistributionService",
-            "providerResourceId": "22c069a9-0cff-4e88-99d8-d0f56dfba231"
-        },
-        {
-            "id": "144e5b36-9ae5-481e-8af8-b0b618e1138d",
-            "deletedDateTime": null,
-            "capability": "MSUPortalRoot",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MSUPortalRoot",
-            "uri": "https://portal.manage.microsoft.com/",
-            "providerResourceId": "4925b020-5d82-48bc-b6d7-86b387700994"
-        },
-        {
-            "id": "a38b44b2-56de-43d9-b09d-718ddb36dfce",
-            "deletedDateTime": null,
-            "capability": "AnonymousClientWebService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AnonymousClientWebService",
-            "uri": "https://msud01.manage.microsoft.com/ClientWebService/client.asmx",
-            "providerResourceId": "9f184cc0-9932-4a2c-9fff-49672940507d"
-        },
-        {
-            "id": "405d17b2-0e3e-4ba4-a4b1-3d10a1c98539",
-            "deletedDateTime": null,
-            "capability": "PartnerTenantDataSyncService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "PartnerTenantDataSyncService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerAPI/StatelessPartnerTenantDataSyncService",
-            "providerResourceId": "7a6cbbb6-f508-40df-adb2-ed155d114fcf"
-        },
-        {
-            "id": "508b6b2f-5d43-4ec3-b7a8-dd59dacbfe59",
-            "deletedDateTime": null,
-            "capability": "TicketingFEServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "TicketingFEServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/PartnerIntegrations/TicketingFEService",
-            "providerResourceId": "1ba04cfb-d4dd-406f-aaea-1a766fc4f217"
-        },
-        {
-            "id": "b4c8328d-1692-4dee-b64c-e1c68bf5ae92",
-            "deletedDateTime": null,
-            "capability": "UserAuthLocationServiceService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "UserAuthLocationServiceService",
-            "uri": "https://manage.microsoft.com/UserAuthLocationService/UserAuthLocationService.svc",
-            "providerResourceId": "df8303a1-16cf-4a63-be8f-17d4691ec369"
-        },
-        {
-            "id": "fe439a59-93e5-48b0-9965-99b9ecd50c54",
-            "deletedDateTime": null,
-            "capability": "StatelessWIPReportFEServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessWIPReportFEServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/WIPReportServices/StatelessWIPReportFEService",
-            "providerResourceId": "1770bb6f-4eb4-4e0a-99da-64a969ce3afc"
-        },
-        {
-            "id": "aceeb79b-e177-4a53-b254-00bd5d25d962",
-            "deletedDateTime": null,
-            "capability": "StatelessResourceManagementService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessResourceManagementService",
-            "uri": "https://fef.msud01.manage.microsoft.com/RMS/StatelessResourceManagementGatewayService/Gateway/StatelessResourceManagementService",
-            "providerResourceId": "b94f560e-2aa7-407f-8e6f-01971e4b4aaa"
-        },
-        {
-            "id": "3e64e399-4178-46a8-bc5e-2bf9bf49f6ca",
-            "deletedDateTime": null,
-            "capability": "AgentEnrollment",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AgentEnrollment",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService",
-            "providerResourceId": "f4e0beba-08ce-4eda-a976-fffdc2156fdd"
-        },
-        {
-            "id": "8d533eb4-0e75-425c-8166-8bc4abbe9e2b",
-            "deletedDateTime": null,
-            "capability": "iOSEnrollment",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "iOSEnrollment",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessIOSEnrollmentService",
-            "providerResourceId": "b6e25c89-7afb-4492-8c68-293e9915a5db"
-        },
-        {
-            "id": "ddcbcd64-a94d-492b-93d8-8a16734799e9",
-            "deletedDateTime": null,
-            "capability": "AgentEnrollmentService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AgentEnrollmentService",
-            "uri": "https://msud01.manage.microsoft.com/AgentEnrollmentService/AgentEnrollmentService.svc",
-            "providerResourceId": "80df35f6-20f9-40d2-8253-901890e8b412"
-        },
-        {
-            "id": "36b7fc3e-f35e-48fe-93a8-c9addb86c5e9",
-            "deletedDateTime": null,
-            "capability": "FencingGatewayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "FencingGatewayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Fencing/FencingSignalService",
-            "providerResourceId": "b68db34e-9953-4ca8-bc12-1b45d1272c84"
-        },
-        {
-            "id": "6d796e55-a464-4042-a972-b3d8247d7c89",
-            "deletedDateTime": null,
-            "capability": "AzureADTokenHandler",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AzureADTokenHandler",
-            "uri": "https://manage.microsoft.com/UISecurityTokenService/StsAadTokenHandler.ashx",
-            "providerResourceId": "b736db37-4457-4047-bc61-b70112421150"
-        },
-        {
-            "id": "2f481fdc-6a95-4a07-954d-ba242a6b8c46",
-            "deletedDateTime": null,
-            "capability": "IWPortalExchangeActivateDevice",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "IWPortalExchangeActivateDevice",
-            "uri": "https://portal.manage.microsoft.com/devices/exchangeActivateDevice",
-            "providerResourceId": "87f59d22-ce73-4cd2-840c-fd5b75c9cf80"
-        },
-        {
-            "id": "78040ee8-6a8d-49eb-bad9-869fac9ddc78",
-            "deletedDateTime": null,
-            "capability": "NACAPIServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "NACAPIServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessNACService",
-            "providerResourceId": "a5d7e199-5ba0-48d1-adba-b4f7c91e8c78"
-        },
-        {
-            "id": "850108d9-3037-40d3-baf3-5829d6248b08",
-            "deletedDateTime": null,
-            "capability": "StatelessRemoteAssistServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessRemoteAssistServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/RemoteAssistService/StatelessRemoteAssistService",
-            "providerResourceId": "0072ec79-1c57-4cb9-9d1c-c2f7f260d158"
-        },
-        {
-            "id": "95041250-88c3-4652-9449-2d8adac77d1f",
-            "deletedDateTime": null,
-            "capability": "SCCMUserSyncService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SCCMUserSyncService",
-            "uri": "https://msud01.manage.microsoft.com/MSUSCCMUserEnable/MSUSccmUserEnable.svc",
-            "providerResourceId": "24d23435-be35-4888-8c2d-6aad049853d4"
-        },
-        {
-            "id": "7d27df9c-89c5-4e7a-970b-99c3d15081be",
-            "deletedDateTime": null,
-            "capability": "RoleAdministration",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "RoleAdministration",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RBAC/StatelessRoleAdministrationFEService",
-            "providerResourceId": "cac892b1-062c-489a-a45c-61320e2530b2"
-        },
-        {
-            "id": "bff2b526-4f26-41c6-a06d-7a903ff11b44",
-            "deletedDateTime": null,
-            "capability": "StatelessAadRelayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessAadRelayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessAadRelayService",
-            "providerResourceId": "9bb1569e-714e-418c-bbf2-5bbe2a2202fd"
-        },
-        {
-            "id": "90b7a305-a475-4e0f-bf31-e02bc6ac59f0",
-            "deletedDateTime": null,
-            "capability": "WebCPAllAppsPage",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "WebCPAllAppsPage",
-            "uri": "https://portal.manage.microsoft.com/apps",
-            "providerResourceId": "362f99a0-8036-45ee-bb5d-f6fd07dd1ce9"
-        },
-        {
-            "id": "620440c6-6a7d-4c10-87be-6c906b6b8761",
-            "deletedDateTime": null,
-            "capability": "SignOut",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SignOut",
-            "uri": "https://manage.microsoft.com/UISecurityTokenService/StsLogout.aspx?wreply=1&identitypartner=OrgId&ru=https://portal.manage.microsoft.com/ssp.aspx",
-            "providerResourceId": "b6d28d43-7e7e-4e84-aba1-d29e1902552b"
-        },
-        {
-            "id": "740740d0-fd2e-4aae-8044-034c87fa6b4f",
-            "deletedDateTime": null,
-            "capability": "GroupPolicyGatewayServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "GroupPolicyGatewayServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/GroupPolicy/GroupPolicyGatewayService",
-            "providerResourceId": "c33ee74c-ca48-4cbb-aca6-c438bef721a1"
-        },
-        {
-            "id": "23e06d58-182f-410f-9df8-c6751b36ef5d",
-            "deletedDateTime": null,
-            "capability": "IWPortalUdaClaimUrl",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "IWPortalUdaClaimUrl",
-            "uri": "https://portal.manage.microsoft.com/devices/link",
-            "providerResourceId": "4c4c3aac-c303-4944-a8c3-b5605f7cd74d"
-        },
-        {
-            "id": "d695bbdc-ff8d-445e-9e19-da6cd92d43e3",
-            "deletedDateTime": null,
-            "capability": "DCV2GraphService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DCV2GraphService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceConfigV2/DCV2GraphService",
-            "providerResourceId": "3f6075ab-88c5-4bfb-baa7-fa8fe773d176"
-        },
-        {
-            "id": "be09bbe9-2e22-4fb8-91a2-96f4c35ce9d6",
-            "deletedDateTime": null,
-            "capability": "NACAPIService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "NACAPIService",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessNACService",
-            "providerResourceId": "67f2d287-21bd-482b-9fdd-672be732729c"
-        },
-        {
-            "id": "ec948f2f-e185-42be-a076-42b6c7d83d7d",
-            "deletedDateTime": null,
-            "capability": "MobilePortalRoot",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MobilePortalRoot",
-            "uri": "https://portal.manage.microsoft.com/",
-            "providerResourceId": "cb5e33dc-10c3-4ef9-9ee4-d56bac82eb0d"
-        },
-        {
-            "id": "f25295ca-ef93-4c14-8d49-b50db9f079f8",
-            "deletedDateTime": null,
-            "capability": "FEIIS_URL",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "FEIIS_URL",
-            "uri": "https://fei.msud01.manage.microsoft.com/",
-            "providerResourceId": "7ea6dad1-40e4-4cf7-ae0e-19d75020652c"
-        },
-        {
-            "id": "2a051380-af89-49b4-a4fa-8a370ae2fe97",
-            "deletedDateTime": null,
-            "capability": "ScepRequestValidationFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ScepRequestValidationFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/StatelessScepRequestValidationService",
-            "providerResourceId": "103641f5-a5c1-48b5-9367-adc309576a58"
-        },
-        {
-            "id": "0a51c607-bfd2-4451-960d-4639d72f67a1",
-            "deletedDateTime": null,
-            "capability": "MobilePortalAllAppsPage",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MobilePortalAllAppsPage",
-            "uri": "https://portal.manage.microsoft.com/apps",
-            "providerResourceId": "ceb035f7-4632-4500-a37a-328ded035921"
-        },
-        {
-            "id": "d69e2fcc-6bd6-4316-b5b3-2c252e76a662",
-            "deletedDateTime": null,
-            "capability": "DeviceConfigurationBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceConfigurationBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessDeviceConfigurationFEService",
-            "providerResourceId": "6281f1e3-19ae-4a34-ac94-f7450c323e56"
-        },
-        {
-            "id": "6bb013d2-1275-4ce8-9681-b0989c63fcbc",
-            "deletedDateTime": null,
-            "capability": "StatelessTEMApiService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessTEMApiService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/TEMService/StatelessTEMApiService",
-            "providerResourceId": "948c2bc1-52d7-4a4b-af68-a81cb2def48e"
-        },
-        {
-            "id": "897a73e5-6767-436a-8d3f-642abc5b10b3",
-            "deletedDateTime": null,
-            "capability": "TaskDownloadService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "TaskDownloadService",
-            "uri": "https://msud01.manage.microsoft.com/RemoteAssistanceService/TaskDownloadService.svc",
-            "providerResourceId": "3521fdd3-c5f1-4df9-9a0a-c7d7e02f8d3a"
-        },
-        {
-            "id": "9819e19c-7f59-45d7-83aa-6f002fceb979",
-            "deletedDateTime": null,
-            "capability": "ExchangeIncomingGateway",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ExchangeIncomingGateway",
-            "uri": "https://msud01.manage.microsoft.com/ExchangeIncomingGateway/GatewayService.svc",
-            "providerResourceId": "f0f81774-a5e4-44d5-b3c3-597c24f8bf7c"
-        },
-        {
-            "id": "d73560ed-83eb-47af-936d-f22cd3ca0bd0",
-            "deletedDateTime": null,
-            "capability": "EmbeddedSIMGatewayServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EmbeddedSIMGatewayServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/EmbeddedSIM/EmbeddedSIMGatewayService",
-            "providerResourceId": "8ab0e016-40d3-45c3-bd65-5bb719aff50f"
-        },
-        {
-            "id": "f0170605-865c-4f39-91f1-f3ba7534a24e",
-            "deletedDateTime": null,
-            "capability": "DeviceConfiguration",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceConfiguration",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceConfiguration/StatelessDeviceConfigurationFEService",
-            "providerResourceId": "852a4ced-ffb3-432f-a30d-0bbbf0185444"
-        },
-        {
-            "id": "c872f021-0403-43c1-be49-f7bfe665f8ce",
-            "deletedDateTime": null,
-            "capability": "ASUName",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ASUName",
-            "uri": "AMSUD0101",
-            "providerResourceId": "2b43d7bc-d485-4626-8073-7005dd4ddb40"
-        },
-        {
-            "id": "5bf08500-3818-4139-bd1c-6824f868a98f",
-            "deletedDateTime": null,
-            "capability": "ImportPFXGatewayServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ImportPFXGatewayServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/RACerts/ImportPFXGatewayService/Gateway/StatelessImportPFXService",
-            "providerResourceId": "9c4a1a0b-3f83-4f1c-9fd1-920ba99b8aec"
-        },
-        {
-            "id": "db118ce7-2828-4b8b-98da-f3a4425c0b54",
-            "deletedDateTime": null,
-            "capability": "EBookMetadata",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EBookMetadata",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AppleVPP/StatelessEBookMetadataFEService",
-            "providerResourceId": "b070a3f0-0dcf-4025-9f45-2840d4915679"
-        },
-        {
-            "id": "cc7fe602-826a-44bc-99a8-afb33cbdd039",
-            "deletedDateTime": null,
-            "capability": "SelfUpdateService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SelfUpdateService",
-            "uri": "http://msud01.manage.microsoft.com/SelfUpdate",
-            "providerResourceId": "71d35e3a-2b56-49eb-ba48-b31500c770a7"
-        },
-        {
-            "id": "e8ac8d44-da3d-4baf-bd31-7d9a08fbde44",
-            "deletedDateTime": null,
-            "capability": "RAODJPlusFEGatewayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "RAODJPlusFEGatewayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RAODJPlus/StatelessODJService",
-            "providerResourceId": "de3041e9-2ef3-4cfc-8799-eaaf1da26ec5"
-        },
-        {
-            "id": "e431ee3b-1fef-4a71-8af2-17dc095b9c21",
-            "deletedDateTime": null,
-            "capability": "DiscoveryService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DiscoveryService",
-            "uri": "https://manage.microsoft.com/EnrollmentServer/Discovery.svc",
-            "providerResourceId": "b57dda70-336a-4d14-9ba3-2e981fce1982"
-        },
-        {
-            "id": "7f0c7aa5-940c-406a-a092-532bff65e69d",
-            "deletedDateTime": null,
-            "capability": "DeviceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/DeviceFE/StatelessDeviceFEService",
-            "providerResourceId": "1be817ff-874c-4db2-934e-c48e7c92e8b1"
-        },
-        {
-            "id": "9e9cd674-ab2e-4314-b672-f194311be342",
-            "deletedDateTime": null,
-            "capability": "StatelessFERemoteAssistOnboardingServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessFERemoteAssistOnboardingServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/RemoteAssistService/StatelessFERemoteAssistOnboardingService",
-            "providerResourceId": "9562d0ca-a8ba-4b77-8a41-c20c2867c471"
-        },
-        {
-            "id": "d152c10e-2822-436d-9cfe-dd39418e5448",
-            "deletedDateTime": null,
-            "capability": "AdminExperience",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AdminExperience",
-            "uri": "https://fef.msud01.manage.microsoft.com/AdminExperienceService",
-            "providerResourceId": "97bfd3ed-8726-4e24-aa6e-bc21156d974a"
-        },
-        {
-            "id": "080894f7-4ab3-4ff4-9ff9-969fde5fb9e8",
-            "deletedDateTime": null,
-            "capability": "FencingGatewayServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "FencingGatewayServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/Fencing/FencingGatewayService",
-            "providerResourceId": "3cd453c8-61a9-45e0-8478-296a44e8ca7e"
-        },
-        {
-            "id": "c56e24fd-d135-46de-8ea4-d3f0d3084d15",
-            "deletedDateTime": null,
-            "capability": "HybridConnectorService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "HybridConnectorService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Hybrid/StatelessConnectorService/",
-            "providerResourceId": "9b023286-5e80-47ec-b082-30c4007c28ff"
-        },
-        {
-            "id": "cab303b0-2e9d-45b7-8c49-5364d0f04333",
-            "deletedDateTime": null,
-            "capability": "AADRelayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AADRelayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessAadRelayService",
-            "providerResourceId": "a30e761d-2f4b-425b-82fe-395cc7944873"
-        },
-        {
-            "id": "09527703-26a3-4f8e-8858-c694fc95a847",
-            "deletedDateTime": null,
-            "capability": "TEMServicePreviewBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "TEMServicePreviewBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessTEMServicePreview",
-            "providerResourceId": "51f4d007-4dc8-4d9e-85a7-17cad7f3ba16"
-        },
-        {
-            "id": "356426f5-e256-4e38-b69a-d321f61dab01",
-            "deletedDateTime": null,
-            "capability": "CertDeliveryFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "CertDeliveryFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/StatelessCertDeliveryService",
-            "providerResourceId": "744b1f7e-1b5d-44a3-9a38-bae526079fa6"
-        },
-        {
-            "id": "40930d73-b904-426c-8b9b-6cb36959978d",
-            "deletedDateTime": null,
-            "capability": "SignalingService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SignalingService",
-            "uri": "https://msud01.manage.microsoft.com/SignalingService/Signal.AsyncHandler",
-            "providerResourceId": "49be223e-a441-465d-bb88-2a7257eeeeda"
-        },
-        {
-            "id": "9194f9cd-fc23-4433-99cb-3dc0ea2be19d",
-            "deletedDateTime": null,
-            "capability": "Service_URL",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "Service_URL",
-            "uri": "https://msud01.manage.microsoft.com/",
-            "providerResourceId": "4ce8423d-f9fa-4834-9b1d-dbab5b891e4c"
-        },
-        {
-            "id": "a2594e2a-7563-449a-b713-2d20709e9c61",
-            "deletedDateTime": null,
-            "capability": "WebCPAllEbooksPage",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "WebCPAllEbooksPage",
-            "uri": "https://portal.manage.microsoft.com/ebooks",
-            "providerResourceId": "9f9426a4-5388-4ea3-800a-2a527667192e"
-        },
-        {
-            "id": "3806cfb9-fb2b-4840-83bb-66f7cb726a95",
-            "deletedDateTime": null,
-            "capability": "EBookMetadataBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EBookMetadataBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/AppleVPP/StatelessEBookMetadataFEService",
-            "providerResourceId": "4736abe1-ea0e-4e9a-bfac-2f8c70f1d193"
-        },
-        {
-            "id": "95d46d2e-27f9-4ad5-8e6f-d6e4f61c07a8",
-            "deletedDateTime": null,
-            "capability": "RAPolicyFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "RAPolicyFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/StatelessRAPolicyService",
-            "providerResourceId": "c1a409c7-f052-477e-b736-09b049f38612"
-        },
-        {
-            "id": "07386af1-f0b3-4ee8-ade9-9f7a7fc35141",
-            "deletedDateTime": null,
-            "capability": "RoleAdministrationBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "RoleAdministrationBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessRoleAdministrationFEService",
-            "providerResourceId": "3ac071e2-8f19-4bef-8895-8e4116939912"
-        },
-        {
-            "id": "61fc8ac9-107f-4357-972a-e31c4d4194e1",
-            "deletedDateTime": null,
-            "capability": "IWPortalExchangeActivationDetailsPage",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "IWPortalExchangeActivationDetailsPage",
-            "uri": "https://portal.manage.microsoft.com/enrollment/getExchangeActivationDetails",
-            "providerResourceId": "3779980c-c866-48e6-9b3c-4bad8a62c1bf"
-        },
-        {
-            "id": "37160ff0-0fea-455a-a7ed-6d7a29bf05bf",
-            "deletedDateTime": null,
-            "capability": "EnrollmentSTS",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EnrollmentSTS",
-            "uri": "https://msud01.manage.microsoft.com/AgentEnrollmentSecurityTokenService/IWSTrust.svc",
-            "providerResourceId": "1fc367c4-3ccf-4fb8-bfea-98cbe9ceb338"
-        },
-        {
-            "id": "ff1d0edd-ff73-400f-8e03-b87a8347918e",
-            "deletedDateTime": null,
-            "capability": "FEF_URL",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "FEF_URL",
-            "uri": "https://fef.msud01.manage.microsoft.com/",
-            "providerResourceId": "14c43a02-ec69-45c2-8f3d-94a58ecb4095"
-        },
-        {
-            "id": "3b685126-5d66-451a-a8ee-36a1ef6ab504",
-            "deletedDateTime": null,
-            "capability": "StatelessTEMApiServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessTEMApiServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessTEMApiService",
-            "providerResourceId": "0033d575-7c02-4050-a6c9-fe956884d846"
-        },
-        {
-            "id": "bb32e857-fa85-497a-a58d-a1bdf62a9538",
-            "deletedDateTime": null,
-            "capability": "CompanyTermFEServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "CompanyTermFEServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessCompanyTermFEService",
-            "providerResourceId": "8923817e-1a6a-4efd-9951-6eba2b4b5075"
-        },
-        {
-            "id": "03b32959-9cdd-4a3f-94f1-9a8a4bd63b31",
-            "deletedDateTime": null,
-            "capability": "PartnerDeviceDataSyncService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "PartnerDeviceDataSyncService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerAPI/StatelessPartnerDeviceDataSyncService",
-            "providerResourceId": "c304cae7-8d07-42dc-a82f-af1055e0b56a"
-        },
-        {
-            "id": "4eba3011-0d3f-4178-98ea-3c17e572d7e3",
-            "deletedDateTime": null,
-            "capability": "WindowsEnrollment",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "WindowsEnrollment",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService/DeviceEnrollment.svc",
-            "providerResourceId": "506451e1-f4d8-4016-af0a-f7e0144babbe"
-        },
-        {
-            "id": "1d547e05-bc16-49e7-bd69-94959ddce6f4",
-            "deletedDateTime": null,
-            "capability": "TEMService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "TEMService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TEMService/StatelessTEMService",
-            "providerResourceId": "7667c928-1705-4d8d-8b14-d0564bb9db68"
-        },
-        {
-            "id": "d4a5bba2-7115-48df-a655-c28ebcc326a4",
-            "deletedDateTime": null,
-            "capability": "DataWarehouse",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DataWarehouse",
-            "uri": "https://fef.msud01.manage.microsoft.com/ReportingService/DataWarehouseFEService",
-            "providerResourceId": "2772ef03-ea2e-400d-8114-6d1be6558493"
-        },
-        {
-            "id": "d2b10900-f87d-43ef-87bd-9e5c8acff68c",
-            "deletedDateTime": null,
-            "capability": "EventWebService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EventWebService",
-            "uri": "https://msud01.manage.microsoft.com/EventWebService/EventWebService.svc",
-            "providerResourceId": "0d2f2577-c97f-4748-bd91-9041c25bb04d"
-        },
-        {
-            "id": "f280c5ff-653f-4635-adff-82ff07f1670d",
-            "deletedDateTime": null,
-            "capability": "UserEnrollmentSTS",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "UserEnrollmentSTS",
-            "uri": "https://msud01.manage.microsoft.com/UserEnrollmentSecurityTokenService/IWSTrust.svc",
-            "providerResourceId": "918fc944-39fc-4e1a-bc56-7a23c8106ccc"
-        },
-        {
-            "id": "9120ec95-fd5b-47f9-9e68-8fb16f9622fb",
-            "deletedDateTime": null,
-            "capability": "GroupPolicyGatewayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "GroupPolicyGatewayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GroupPolicy/GroupPolicyAdminService",
-            "providerResourceId": "bb57edf0-72e0-467c-be77-24ff90821edf"
-        },
-        {
-            "id": "4efb9bd2-ad51-4437-ab01-5097d17a548e",
-            "deletedDateTime": null,
-            "capability": "NotificationMessageTemplateBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "NotificationMessageTemplateBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessNotificationFEService",
-            "providerResourceId": "50c19f8a-b92a-4649-97e3-9d7aa7c5066f"
-        },
-        {
-            "id": "ce153ea3-84e0-4a33-967a-9aec3a91b11f",
-            "deletedDateTime": null,
-            "capability": "DeviceManagementIntent",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DeviceManagementIntent",
-            "uri": "https://fef.msud01.manage.microsoft.com/DeviceManagementIntent/DeviceManagementIntentGatewayService/Gateway/DeviceManagementIntentService",
-            "providerResourceId": "03f47fc7-3349-4e79-928e-5389e5c4ed7a"
-        },
-        {
-            "id": "0200987b-4606-4660-8cc4-a4863b4749dc",
-            "deletedDateTime": null,
-            "capability": "DiagnosticServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DiagnosticServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/DiagnosticService/StatelessDiagnosticService",
-            "providerResourceId": "73dda844-ef12-48c1-b42f-c5562d55d675"
-        },
-        {
-            "id": "05dbdd7a-9171-4b9d-9702-3f82ec888396",
-            "deletedDateTime": null,
-            "capability": "TEMServicePreview",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "TEMServicePreview",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessTEMServicePreview",
-            "providerResourceId": "884d2bf2-1190-4169-94f8-785d74722f66"
-        },
-        {
-            "id": "a0bfaa9c-f2a8-441f-a583-384dafed1245",
-            "deletedDateTime": null,
-            "capability": "EmbeddedSIMAdminServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EmbeddedSIMAdminServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/EmbeddedSIM/EmbeddedSIMGatewayService/Gateway/EmbeddedSIMService",
-            "providerResourceId": "2d402308-d0e3-49c4-a879-d6aa712e35f7"
-        },
-        {
-            "id": "589027f9-b408-4706-9d51-ce7c8d0d08b8",
-            "deletedDateTime": null,
-            "capability": "SupportService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SupportService",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessSupportService",
-            "providerResourceId": "db9e92ba-f21c-40f9-a7b3-5a08255b921a"
-        },
-        {
-            "id": "19f445d0-8226-434c-aba4-d9ec103cd480",
-            "deletedDateTime": null,
-            "capability": "UnlockService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "UnlockService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AppLifecycle/StatelessUnlockV4Service",
-            "providerResourceId": "cd93f9a4-0b3e-4a6d-88a8-f4daa6ff97ff"
-        },
-        {
-            "id": "fbdbea5f-cf47-4efa-812d-3869e917bc1b",
-            "deletedDateTime": null,
-            "capability": "AgentSupportingSTS",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AgentSupportingSTS",
-            "uri": "https://msud01.manage.microsoft.com/AgentSupportingSecurityTokenService/IWSTrust.svc",
-            "providerResourceId": "dae4af48-b55d-4cbf-9735-da897a19249a"
-        },
-        {
-            "id": "e13e205c-311e-49ab-bf96-fdbf6b592ecb",
-            "deletedDateTime": null,
-            "capability": "MAMAdminFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MAMAdminFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/MAMAdmin/MAMAdminFEService",
-            "providerResourceId": "3bdf5a53-7597-4b48-9f65-389ee28864c8"
-        },
-        {
-            "id": "a5b0e206-9da7-4a4d-b773-ba30c2492dbc",
-            "deletedDateTime": null,
-            "capability": "EmbeddedSIMAdminService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EmbeddedSIMAdminService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/EmbeddedSIM/EmbeddedSIMService",
-            "providerResourceId": "d23132fa-3af3-4454-82f5-a1b3e69d3cd8"
-        },
-        {
-            "id": "7c6a605e-1584-46a8-b825-9915523d11de",
-            "deletedDateTime": null,
-            "capability": "CorrelationServiceEndpointUrl",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "CorrelationServiceEndpointUrl",
-            "uri": "https://correlationservice.aus.manage.microsoft.com",
-            "providerResourceId": "cae8f6f3-2ac3-4c14-b0a4-c4cd5b71338c"
-        },
-        {
-            "id": "cf3fe8ac-a807-466a-9716-b270eae343c2",
-            "deletedDateTime": null,
-            "capability": "EmbeddedSIMGatewayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EmbeddedSIMGatewayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/EmbeddedSIM/EmbeddedSIMService",
-            "providerResourceId": "c7f54c05-75a2-440e-8dcf-1a95c38dc25c"
-        },
-        {
-            "id": "bd21cd8e-b508-45b4-8d1b-9f9825b101e2",
-            "deletedDateTime": null,
-            "capability": "SoftwareUpdateGatewayServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SoftwareUpdateGatewayServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/Updates/SoftwareUpdateGatewayService",
-            "providerResourceId": "91797937-1567-47de-85c1-9e628646c0b6"
-        },
-        {
-            "id": "b4f547da-4f89-42d6-9dc5-ea4a3f8f7676",
-            "deletedDateTime": null,
-            "capability": "ClientLogonPage",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ClientLogonPage",
-            "uri": "https://portal.manage.microsoft.com/Home/ClientLogon/?tt=saml",
-            "providerResourceId": "433fd2fe-731b-41f0-8d21-5c292e1a89e6"
-        },
-        {
-            "id": "f14136f4-9c03-45bc-b36d-77e93cfe32a4",
-            "deletedDateTime": null,
-            "capability": "MicrosoftTunnelService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "MicrosoftTunnelService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/MobileAccess/MicrosoftTunnelService",
-            "providerResourceId": "e6c5aacf-529b-4065-ba77-755a1066eb8d"
-        },
-        {
-            "id": "abbe1e7c-5761-4b5b-88a2-23ceb3dec611",
-            "deletedDateTime": null,
-            "capability": "SideCarGatewayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "SideCarGatewayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/SideCar/StatelessSideCarGatewayService",
-            "providerResourceId": "33ef708d-2575-4336-80bf-8739b2fc419d"
-        },
-        {
-            "id": "28914e73-7d93-4e44-b983-a1c415369189",
-            "deletedDateTime": null,
-            "capability": "PolicySetService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "PolicySetService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GnT/StatelessPayloadLinkingService",
-            "providerResourceId": "eb68505c-22de-40fd-87a9-af3129be7fc6"
-        },
-        {
-            "id": "6c833a10-da5b-4f48-8f09-ba380c6dba9e",
-            "deletedDateTime": null,
-            "capability": "CustomerDataServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "CustomerDataServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessCustomerDataFEService",
-            "providerResourceId": "e1629b41-9fd1-4c5a-a9e4-acfe122be1fe"
-        },
-        {
-            "id": "88cfd6b9-2623-4ea5-9e9b-0c5d843bea54",
-            "deletedDateTime": null,
-            "capability": "StatelessAadRelayServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessAadRelayServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/StatelessAadRelayService",
-            "providerResourceId": "8b7ee696-1dd6-4449-8098-ec407397ac1a"
-        },
-        {
-            "id": "954a387e-45f6-4762-96b0-8c33dbc1d29f",
-            "deletedDateTime": null,
-            "capability": "AgentSTS",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AgentSTS",
-            "uri": "https://msud01.manage.microsoft.com/AgentSecurityTokenService/IWSTrust.svc",
-            "providerResourceId": "799ac981-2865-47f6-a409-8c8d1caee96b"
-        },
-        {
-            "id": "255cea63-a768-48b6-8dc4-f4da0bfee28c",
-            "deletedDateTime": null,
-            "capability": "NDESConnectorService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "NDESConnectorService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Hybrid/StatelessConnectorService/",
-            "providerResourceId": "cba5b375-d360-4264-8f47-b3c3d7ba956f"
-        },
-        {
-            "id": "a0c11d53-7a20-4f44-a395-312e0e3888ed",
-            "deletedDateTime": null,
-            "capability": "ComplianceRetrievalService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ComplianceRetrievalService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ResourceAccess/ComplianceRetrievalService",
-            "providerResourceId": "79d8182f-80db-4b0c-b737-60ac65eaf821"
-        },
-        {
-            "id": "5f8e7fd4-b555-4112-82bf-f438b794422f",
-            "deletedDateTime": null,
-            "capability": "StatelessChromebookSyncService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "StatelessChromebookSyncService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ChromebookSync/StatelessChromebookSyncService",
-            "providerResourceId": "8b8d18d6-fb84-4772-9bf9-129cbd0ba487"
-        },
-        {
-            "id": "9fdec3a7-1778-4ea2-ae6d-40ab4353e08d",
-            "deletedDateTime": null,
-            "capability": "ChromebookSyncService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ChromebookSyncService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ChromebookSync/ChromebookSyncService",
-            "providerResourceId": "918ef2ca-c382-4681-8567-0dce5407d336"
-        },
-        {
-            "id": "4f0b4d9b-24a3-4c0c-b36b-5d64bdef10a3",
-            "deletedDateTime": null,
-            "capability": "AppleRemoteManagementService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AppleRemoteManagementService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AppleMDM/AppleRemoteManagementService",
-            "providerResourceId": "a36dd38b-316b-4a63-9ca1-50604f790ebc"
-        },
-        {
-            "id": "b2d79d5b-c09a-421d-af72-fd0f1fdc409b",
-            "deletedDateTime": null,
-            "capability": "RAConnectorsTelemetryService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "RAConnectorsTelemetryService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/RAConnectorsTelemetryService",
-            "providerResourceId": "fe11edb2-c652-4bf5-9b1e-636b42e31874"
-        },
-        {
-            "id": "31198ad1-9dac-4dee-91bc-60d8f663a8df",
-            "deletedDateTime": null,
-            "capability": "PartnerComplianceService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "PartnerComplianceService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Compliance/PartnerComplianceService",
-            "providerResourceId": "1cfacb92-8d3a-43ed-af34-88994414d449"
-        },
-        {
-            "id": "26cb4c57-8229-475b-aea7-bbce391a4ec1",
-            "deletedDateTime": null,
-            "capability": "AndroidFOTAService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AndroidFOTAService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AndroidSpecialized/AndroidFOTAService",
-            "providerResourceId": "e71c0be0-1548-4aba-9f4c-599fe2c3c246"
-        },
-        {
-            "id": "a78bbdbf-7bf8-4476-b0c5-7d4191389b65",
-            "deletedDateTime": null,
-            "capability": "BrandingService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "BrandingService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Wcs/StatelessBrandingService",
-            "providerResourceId": "780c991c-29ed-4635-88d0-4c1de7113652"
-        },
-        {
-            "id": "137a027b-95cb-4240-aef4-8ad4ed084010",
-            "deletedDateTime": null,
-            "capability": "DepFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "DepFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Dep/DepFEService",
-            "providerResourceId": "dd6a823d-9a9a-419e-bb01-ec79f03f288e"
-        },
-        {
-            "id": "24b94131-b143-42a3-b05d-896dd00013ee",
-            "deletedDateTime": null,
-            "capability": "LinuxDeviceCheckinService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "LinuxDeviceCheckinService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/LinuxMdm/LinuxDeviceCheckinService",
-            "providerResourceId": "491a5d24-b216-4c3f-a819-a5d152d08738"
-        },
-        {
-            "id": "8030fef0-8fa0-4486-b37c-3779b292b0ba",
-            "deletedDateTime": null,
-            "capability": "NotificationPollingService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "NotificationPollingService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RTNService/NotificationPollingService",
-            "providerResourceId": "5a68e2d0-5b37-4709-9db3-ec7c53ee874d"
-        },
-        {
-            "id": "f47e3189-ba2c-4729-b718-d3ee4d316499",
-            "deletedDateTime": null,
-            "capability": "PowerLiftService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "PowerLiftService",
-            "uri": "https://powerlift-frontdesk.acompli.net",
-            "providerResourceId": "bc86bde1-ef53-4a85-b551-8aad6a7e7642"
-        },
-        {
-            "id": "38a82e87-d1cc-4588-973f-5343b25f4b53",
-            "deletedDateTime": null,
-            "capability": "AriaService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AriaService",
-            "uri": "https://self.events.data.microsoft.com",
-            "providerResourceId": "70233926-075c-4036-9e3e-6df4d8204d44"
-        },
-        {
-            "id": "b416fe44-97c1-4467-893d-0422d21d5278",
-            "deletedDateTime": null,
-            "capability": "ServiceNowConnector",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ServiceNowConnector",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ReportingService/ServiceNowConnector",
-            "providerResourceId": "f246dc98-b1f5-4076-a826-349d43ffe1e4"
-        },
-        {
-            "id": "6560a280-2b94-4ec3-ace0-9873ae6d4ee6",
-            "deletedDateTime": null,
-            "capability": "ServiceNowConnectorService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ServiceNowConnectorService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ITConnection/ServiceNowConnectorService",
-            "providerResourceId": "fd9ef2d2-592b-4d71-b8d1-f5c8723562c5"
-        },
-        {
-            "id": "01687c0f-cb16-4055-9480-6adbcbdd5e9f",
-            "deletedDateTime": null,
-            "capability": "PartnerDeviceDataSyncServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "PartnerDeviceDataSyncServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerAPI/StatelessPartnerDeviceDataSyncService",
-            "providerResourceId": "6591235b-52a7-49a5-9273-45531a2ea542"
-        },
-        {
-            "id": "3766bfd1-2953-4312-8a84-ad8f9a7b6133",
-            "deletedDateTime": null,
-            "capability": "PartnerTenantDataSyncServiceBackup",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "PartnerTenantDataSyncServiceBackup",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerAPI/StatelessPartnerTenantDataSyncService",
-            "providerResourceId": "8549e73e-25ed-46b4-849d-ebe6ab1aa30c"
-        },
-        {
-            "id": "0f9b61f5-e7a4-47d7-9537-1058cb3742bd",
-            "deletedDateTime": null,
-            "capability": "CollectorService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "CollectorService",
-            "uri": "https://au-mobile.events.data.microsoft.com/OneCollector/1.0/",
-            "providerResourceId": "c885182c-6773-49a9-8ba8-e7de534ac24f"
-        },
-        {
-            "id": "66f36e41-e7ca-41c1-aa0b-c0fddf795beb",
-            "deletedDateTime": null,
-            "capability": "CloudPkiGraphService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "CloudPkiGraphService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/CloudPki/CloudPkiGraphService",
-            "providerResourceId": "4adc63e7-116f-42e6-90c6-354ad57694a7"
-        },
-        {
-            "id": "1b9ee7c8-9864-4465-b6a6-f6d323c7ad72",
-            "deletedDateTime": null,
-            "capability": "ForceUpdateEndpoint",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "ForceUpdateEndpoint",
-            "uri": "https://fef.msud01.manage.microsoft.com/ForceUpdateEndpoint",
-            "providerResourceId": "5cb2f907-cf66-4c44-8c43-a337106e9acd"
-        },
-        {
-            "id": "72fd1790-b0c3-4179-9156-a5c9bbc3f18e",
-            "deletedDateTime": null,
-            "capability": "PolicyListingService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "PolicyListingService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GPAnalytics/PolicyListingService",
-            "providerResourceId": "7b8614fc-ef54-465f-a9bc-9d276129d402"
-        },
-        {
-            "id": "ba1119ba-1d70-4fe6-b371-2d9205375345",
-            "deletedDateTime": null,
-            "capability": "OSRecoveryService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "OSRecoveryService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/OSProvisioning/OSRecoveryService",
-            "providerResourceId": "1e640b9e-e591-40f4-ac12-d1847db98e78"
-        },
-        {
-            "id": "543b63ec-3cc2-4c1c-8ef0-9cddb45b9cb4",
-            "deletedDateTime": null,
-            "capability": "EpmGraphApiService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "EpmGraphApiService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GPAnalytics/EpmGraphApiService",
-            "providerResourceId": "76c48d04-98a9-4b6b-9d0d-1a83b679c343"
-        },
-        {
-            "id": "856a136b-1978-41f0-aa0e-abc3d8c42df1",
-            "deletedDateTime": null,
-            "capability": "CloudPkiFEService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "CloudPkiFEService",
-            "uri": "https://fef.msud01.manage.microsoft.com/CloudPki/CloudPkiFEService",
-            "providerResourceId": "b8def4bc-6881-437f-ac23-a683343d3916"
-        },
-        {
-            "id": "57cb43bf-ec3e-4099-98d1-7130bde33c17",
-            "deletedDateTime": null,
-            "capability": "OSProvisioningGraphService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "OSProvisioningGraphService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/OSProvisioning/OSProvisioningGraphService",
-            "providerResourceId": "b6996d3c-0cb2-4de3-9a8a-eccd9e78b4f3"
-        },
-        {
-            "id": "6f3461c2-c4e2-4e81-bb39-ae57f7c402bf",
-            "deletedDateTime": null,
-            "capability": "AndroidDeviceGatewayService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AndroidDeviceGatewayService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AndroidSync/AndroidDeviceGatewayService",
-            "providerResourceId": "8ecbef08-1e8e-47df-8454-2fb856d7f561"
-        },
-        {
-            "id": "d665bc9d-0ac3-4dc5-bca2-2eacaa737d3f",
-            "deletedDateTime": null,
-            "capability": "AppleEnrollmentService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AppleEnrollmentService",
-            "uri": "https://fef.msud01.manage.microsoft.com/DeviceEnrollmentFE/AppleEnrollmentService",
-            "providerResourceId": "f3a773e7-0e61-48b3-ba4c-5e125261cdf5"
-        },
-        {
-            "id": "277417ff-1169-4bf0-b30a-9ba400ed8282",
-            "deletedDateTime": null,
-            "capability": "UserOffboardingService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "UserOffboardingService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceLifecycle/UserOffboardingService",
-            "providerResourceId": "4dab45a8-0f35-4ed1-8f24-1787b1ad3e70"
-        },
-        {
-            "id": "7a2f3ba5-a899-4a76-a53b-332b01fcebfd",
-            "deletedDateTime": null,
-            "capability": "LinuxEnrollmentService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "LinuxEnrollmentService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/LinuxMDM/LinuxEnrollmentService",
-            "providerResourceId": "e5b950e6-96b7-423b-99a3-76d4039d8a76"
-        },
-        {
-            "id": "8674edbd-a750-4ef0-85c1-2d802ee3a137",
-            "deletedDateTime": null,
-            "capability": "QueryBrokerService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "QueryBrokerService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DataInfra/QueryBrokerFSIService",
-            "providerResourceId": "c360c10e-9381-4ba2-9cc8-af1b6953ac17"
-        },
-        {
-            "id": "55e406ed-9851-4603-854f-32e4dbf8fae8",
-            "deletedDateTime": null,
-            "capability": "AuthenticatedAppleEnrollmentService",
-            "providerId": "0000000a-0000-0000-c000-000000000000",
-            "providerName": "AuthenticatedAppleEnrollmentService",
-            "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceEnrollmentFE/AuthenticatedAppleEnrollmentService",
-            "providerResourceId": "84d576e5-5f27-4a6d-986b-d67d8685f7bc"
-        }
-    ]
-}
+[
+    {
+        "id": "cab303b0-2e9d-45b7-8c49-5364d0f04333",
+        "deletedDateTime": null,
+        "capability": "AADRelayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AADRelayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessAadRelayService",
+        "providerResourceId": "a30e761d-2f4b-425b-82fe-395cc7944873"
+    },
+    {
+        "id": "c872f021-0403-43c1-be49-f7bfe665f8ce",
+        "deletedDateTime": null,
+        "capability": "ASUName",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ASUName",
+        "uri": "AMSUD0101",
+        "providerResourceId": "2b43d7bc-d485-4626-8073-7005dd4ddb40"
+    },
+    {
+        "id": "d152c10e-2822-436d-9cfe-dd39418e5448",
+        "deletedDateTime": null,
+        "capability": "AdminExperience",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AdminExperience",
+        "uri": "https://fef.msud01.manage.microsoft.com/AdminExperienceService",
+        "providerResourceId": "97bfd3ed-8726-4e24-aa6e-bc21156d974a"
+    },
+    {
+        "id": "5bcc67d4-e898-4944-a279-fd59b3bc00c7",
+        "deletedDateTime": null,
+        "capability": "AdminExperienceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AdminExperienceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/AdminExperienceService",
+        "providerResourceId": "bdbf7aff-2170-4c46-9b63-11a9e184a92b"
+    },
+    {
+        "id": "3e64e399-4178-46a8-bc5e-2bf9bf49f6ca",
+        "deletedDateTime": null,
+        "capability": "AgentEnrollment",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AgentEnrollment",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService",
+        "providerResourceId": "f4e0beba-08ce-4eda-a976-fffdc2156fdd"
+    },
+    {
+        "id": "716efdc6-d231-4684-bb99-8caf9d1c9245",
+        "deletedDateTime": null,
+        "capability": "AgentEnrollmentRenewal",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AgentEnrollmentRenewal",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService",
+        "providerResourceId": "f6455ac6-9993-47ff-b7a5-2e9961def720"
+    },
+    {
+        "id": "ddcbcd64-a94d-492b-93d8-8a16734799e9",
+        "deletedDateTime": null,
+        "capability": "AgentEnrollmentService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AgentEnrollmentService",
+        "uri": "https://msud01.manage.microsoft.com/AgentEnrollmentService/AgentEnrollmentService.svc",
+        "providerResourceId": "80df35f6-20f9-40d2-8253-901890e8b412"
+    },
+    {
+        "id": "954a387e-45f6-4762-96b0-8c33dbc1d29f",
+        "deletedDateTime": null,
+        "capability": "AgentSTS",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AgentSTS",
+        "uri": "https://msud01.manage.microsoft.com/AgentSecurityTokenService/IWSTrust.svc",
+        "providerResourceId": "799ac981-2865-47f6-a409-8c8d1caee96b"
+    },
+    {
+        "id": "fbdbea5f-cf47-4efa-812d-3869e917bc1b",
+        "deletedDateTime": null,
+        "capability": "AgentSupportingSTS",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AgentSupportingSTS",
+        "uri": "https://msud01.manage.microsoft.com/AgentSupportingSecurityTokenService/IWSTrust.svc",
+        "providerResourceId": "dae4af48-b55d-4cbf-9735-da897a19249a"
+    },
+    {
+        "id": "8b945e3a-ae10-42ad-89b3-5e2bb6c12eba",
+        "deletedDateTime": null,
+        "capability": "AndroidDeviceGatewayCertificateService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AndroidDeviceGatewayCertificateService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/PassThroughRoutingService/AndroidSync/AndroidDeviceGatewayCertificateService",
+        "providerResourceId": "95dbdfb0-2f24-4b52-bd4a-89781cabdaa1"
+    },
+    {
+        "id": "6f3461c2-c4e2-4e81-bb39-ae57f7c402bf",
+        "deletedDateTime": null,
+        "capability": "AndroidDeviceGatewayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AndroidDeviceGatewayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AndroidSync/AndroidDeviceGatewayService",
+        "providerResourceId": "8ecbef08-1e8e-47df-8454-2fb856d7f561"
+    },
+    {
+        "id": "384379cb-9aaa-4f00-a413-33d1c5b507bb",
+        "deletedDateTime": null,
+        "capability": "AndroidEnrollment",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AndroidEnrollment",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService/DeviceEnrollment.svc",
+        "providerResourceId": "85ae7b66-5278-438d-a072-c36c649c37bc"
+    },
+    {
+        "id": "26cb4c57-8229-475b-aea7-bbce391a4ec1",
+        "deletedDateTime": null,
+        "capability": "AndroidFOTAService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AndroidFOTAService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AndroidSpecialized/AndroidFOTAService",
+        "providerResourceId": "e71c0be0-1548-4aba-9f4c-599fe2c3c246"
+    },
+    {
+        "id": "a38b44b2-56de-43d9-b09d-718ddb36dfce",
+        "deletedDateTime": null,
+        "capability": "AnonymousClientWebService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AnonymousClientWebService",
+        "uri": "https://msud01.manage.microsoft.com/ClientWebService/client.asmx",
+        "providerResourceId": "9f184cc0-9932-4a2c-9fff-49672940507d"
+    },
+    {
+        "id": "f96dbfcc-8749-44ef-b6c4-67a826f85f70",
+        "deletedDateTime": null,
+        "capability": "AospProvisioningService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AospProvisioningService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/PassThroughRoutingService/AndroidSpecialized/AospProvisioningService",
+        "providerResourceId": "c6195456-dad1-467f-aba7-a55095986e72"
+    },
+    {
+        "id": "7ee4ca2f-fa1b-41ec-b465-248597eda3ce",
+        "deletedDateTime": null,
+        "capability": "AppMetadata",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AppMetadata",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AppLifecycle/StatelessAppMetadataFEService",
+        "providerResourceId": "74fe29b9-0806-43d5-b95b-663a886cfcea"
+    },
+    {
+        "id": "56acfe19-7da6-466d-a73e-922b5bfffe4f",
+        "deletedDateTime": null,
+        "capability": "AppMetadataBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AppMetadataBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/AppLifecycle/StatelessAppMetadataFEService",
+        "providerResourceId": "714d24e0-a5cd-4d6f-a922-fdd51af68d63"
+    },
+    {
+        "id": "d665bc9d-0ac3-4dc5-bca2-2eacaa737d3f",
+        "deletedDateTime": null,
+        "capability": "AppleEnrollmentService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AppleEnrollmentService",
+        "uri": "https://fef.msud01.manage.microsoft.com/DeviceEnrollmentFE/AppleEnrollmentService",
+        "providerResourceId": "f3a773e7-0e61-48b3-ba4c-5e125261cdf5"
+    },
+    {
+        "id": "4f0b4d9b-24a3-4c0c-b36b-5d64bdef10a3",
+        "deletedDateTime": null,
+        "capability": "AppleRemoteManagementService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AppleRemoteManagementService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AppleMDM/AppleRemoteManagementService",
+        "providerResourceId": "a36dd38b-316b-4a63-9ca1-50604f790ebc"
+    },
+    {
+        "id": "02d72757-4640-456c-af71-0b79c0e94d2e",
+        "deletedDateTime": null,
+        "capability": "ApplicationCheckIn",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ApplicationCheckIn",
+        "uri": "https://fef.msud01.manage.microsoft.com/DeviceCheckin/SLDMService/ApplicationCheckIn",
+        "providerResourceId": "a6e1bb9e-0e43-4354-a332-13254bd7bee4"
+    },
+    {
+        "id": "66d24ca5-3e63-4536-84fa-483ba3f1c225",
+        "deletedDateTime": null,
+        "capability": "ApplicationEnrollment",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ApplicationEnrollment",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService",
+        "providerResourceId": "fd6535fb-38cd-4735-960b-2eb3d3606605"
+    },
+    {
+        "id": "38a82e87-d1cc-4588-973f-5343b25f4b53",
+        "deletedDateTime": null,
+        "capability": "AriaService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AriaService",
+        "uri": "https://self.events.data.microsoft.com",
+        "providerResourceId": "70233926-075c-4036-9e3e-6df4d8204d44"
+    },
+    {
+        "id": "439c0216-2ca8-4764-b1a0-30cb59493ffd",
+        "deletedDateTime": null,
+        "capability": "Auditing",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "Auditing",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Auditing/StatelessAuditingFEService",
+        "providerResourceId": "d3ec4417-ee69-4f41-866a-0d130837047b"
+    },
+    {
+        "id": "da9a7580-c89c-4ea9-ae99-104acf271a91",
+        "deletedDateTime": null,
+        "capability": "AuditingBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AuditingBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessAuditingFEService",
+        "providerResourceId": "139eee2e-8519-46b9-b1d6-b45b02407a31"
+    },
+    {
+        "id": "55e406ed-9851-4603-854f-32e4dbf8fae8",
+        "deletedDateTime": null,
+        "capability": "AuthenticatedAppleEnrollmentService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AuthenticatedAppleEnrollmentService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceEnrollmentFE/AuthenticatedAppleEnrollmentService",
+        "providerResourceId": "84d576e5-5f27-4a6d-986b-d67d8685f7bc"
+    },
+    {
+        "id": "4cdd8686-b1df-4344-af55-666d6724405b",
+        "deletedDateTime": null,
+        "capability": "AuthenticatedIOSEnrollmentService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AuthenticatedIOSEnrollmentService",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessIOSEnrollmentService",
+        "providerResourceId": "fcdfe381-bc43-42a5-bff6-e5151f2e996e"
+    },
+    {
+        "id": "6d796e55-a464-4042-a972-b3d8247d7c89",
+        "deletedDateTime": null,
+        "capability": "AzureADTokenHandler",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "AzureADTokenHandler",
+        "uri": "https://manage.microsoft.com/UISecurityTokenService/StsAadTokenHandler.ashx",
+        "providerResourceId": "b736db37-4457-4047-bc61-b70112421150"
+    },
+    {
+        "id": "a78bbdbf-7bf8-4476-b0c5-7d4191389b65",
+        "deletedDateTime": null,
+        "capability": "BrandingService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "BrandingService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Wcs/StatelessBrandingService",
+        "providerResourceId": "780c991c-29ed-4635-88d0-4c1de7113652"
+    },
+    {
+        "id": "80dbd81d-b962-4cd1-a2c0-b40f50ea175a",
+        "deletedDateTime": null,
+        "capability": "BrandingServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "BrandingServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessBrandingService",
+        "providerResourceId": "7623a913-0de5-4b4b-acf4-6ba3f17f82ee"
+    },
+    {
+        "id": "356426f5-e256-4e38-b69a-d321f61dab01",
+        "deletedDateTime": null,
+        "capability": "CertDeliveryFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "CertDeliveryFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/StatelessCertDeliveryService",
+        "providerResourceId": "744b1f7e-1b5d-44a3-9a38-bae526079fa6"
+    },
+    {
+        "id": "9fdec3a7-1778-4ea2-ae6d-40ab4353e08d",
+        "deletedDateTime": null,
+        "capability": "ChromebookSyncService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ChromebookSyncService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ChromebookSync/ChromebookSyncService",
+        "providerResourceId": "918ef2ca-c382-4681-8567-0dce5407d336"
+    },
+    {
+        "id": "b4f547da-4f89-42d6-9dc5-ea4a3f8f7676",
+        "deletedDateTime": null,
+        "capability": "ClientLogonPage",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ClientLogonPage",
+        "uri": "https://portal.manage.microsoft.com/Home/ClientLogon/?tt=saml",
+        "providerResourceId": "433fd2fe-731b-41f0-8d21-5c292e1a89e6"
+    },
+    {
+        "id": "fffc740d-dc6d-4493-bab2-b9030f819320",
+        "deletedDateTime": null,
+        "capability": "ClientWebService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ClientWebService",
+        "uri": "https://msud01.manage.microsoft.com/ClientWebService/client.asmx/auth",
+        "providerResourceId": "3ad71fd9-6969-4426-8379-e7f2d7d6e1fc"
+    },
+    {
+        "id": "856a136b-1978-41f0-aa0e-abc3d8c42df1",
+        "deletedDateTime": null,
+        "capability": "CloudPkiFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "CloudPkiFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/CloudPki/CloudPkiFEService",
+        "providerResourceId": "b8def4bc-6881-437f-ac23-a683343d3916"
+    },
+    {
+        "id": "66f36e41-e7ca-41c1-aa0b-c0fddf795beb",
+        "deletedDateTime": null,
+        "capability": "CloudPkiGraphService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "CloudPkiGraphService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/CloudPki/CloudPkiGraphService",
+        "providerResourceId": "4adc63e7-116f-42e6-90c6-354ad57694a7"
+    },
+    {
+        "id": "0f9b61f5-e7a4-47d7-9537-1058cb3742bd",
+        "deletedDateTime": null,
+        "capability": "CollectorService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "CollectorService",
+        "uri": "https://au-mobile.events.data.microsoft.com/OneCollector/1.0/",
+        "providerResourceId": "c885182c-6773-49a9-8ba8-e7de534ac24f"
+    },
+    {
+        "id": "231dedb0-9285-44e3-94d5-b79279e4a84e",
+        "deletedDateTime": null,
+        "capability": "CompanyTermFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "CompanyTermFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/CompanyTerms/StatelessCompanyTermFEService",
+        "providerResourceId": "f3f7111f-0670-499f-a5b6-a701bb903146"
+    },
+    {
+        "id": "bb32e857-fa85-497a-a58d-a1bdf62a9538",
+        "deletedDateTime": null,
+        "capability": "CompanyTermFEServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "CompanyTermFEServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessCompanyTermFEService",
+        "providerResourceId": "8923817e-1a6a-4efd-9951-6eba2b4b5075"
+    },
+    {
+        "id": "a0c11d53-7a20-4f44-a395-312e0e3888ed",
+        "deletedDateTime": null,
+        "capability": "ComplianceRetrievalService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ComplianceRetrievalService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ResourceAccess/ComplianceRetrievalService",
+        "providerResourceId": "79d8182f-80db-4b0c-b737-60ac65eaf821"
+    },
+    {
+        "id": "b4753d9e-5cec-435c-9370-4352d3a17d8b",
+        "deletedDateTime": null,
+        "capability": "ConfigManagerConnectorSTS",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ConfigManagerConnectorSTS",
+        "uri": "https://msud01.manage.microsoft.com/ConfigManagerConnectorSecurityTokenService/IWSTrust.svc",
+        "providerResourceId": "eba6869b-c2e5-4e43-8b75-c3426a5726b2"
+    },
+    {
+        "id": "c73eb9bf-c889-46e3-91a6-d37e21c25544",
+        "deletedDateTime": null,
+        "capability": "CorporateDeviceEnrollment",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "CorporateDeviceEnrollment",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessCorporateDeviceEnrollmentService",
+        "providerResourceId": "6effb704-3195-45e5-ba1f-8e1dfd96f812"
+    },
+    {
+        "id": "7c6a605e-1584-46a8-b825-9915523d11de",
+        "deletedDateTime": null,
+        "capability": "CorrelationServiceEndpointUrl",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "CorrelationServiceEndpointUrl",
+        "uri": "https://correlationservice.aus.manage.microsoft.com",
+        "providerResourceId": "cae8f6f3-2ac3-4c14-b0a4-c4cd5b71338c"
+    },
+    {
+        "id": "f1df8dab-39ff-4347-afba-62712625c47a",
+        "deletedDateTime": null,
+        "capability": "CustomerDataService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "CustomerDataService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Wcs/StatelessCustomerDataFEService",
+        "providerResourceId": "c1dd4d39-b85f-4265-9c87-6e4243e7ae79"
+    },
+    {
+        "id": "6c833a10-da5b-4f48-8f09-ba380c6dba9e",
+        "deletedDateTime": null,
+        "capability": "CustomerDataServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "CustomerDataServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessCustomerDataFEService",
+        "providerResourceId": "e1629b41-9fd1-4c5a-a9e4-acfe122be1fe"
+    },
+    {
+        "id": "d695bbdc-ff8d-445e-9e19-da6cd92d43e3",
+        "deletedDateTime": null,
+        "capability": "DCV2GraphService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DCV2GraphService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceConfigV2/DCV2GraphService",
+        "providerResourceId": "3f6075ab-88c5-4bfb-baa7-fa8fe773d176"
+    },
+    {
+        "id": "7efed656-0074-403b-b686-5489a0bb1b43",
+        "deletedDateTime": null,
+        "capability": "DataInfraPartnerService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DataInfraPartnerService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DataInfra/PartnerService",
+        "providerResourceId": "b6bdb30a-010a-4ee9-a36d-ee8adb1793eb"
+    },
+    {
+        "id": "d4a5bba2-7115-48df-a655-c28ebcc326a4",
+        "deletedDateTime": null,
+        "capability": "DataWarehouse",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DataWarehouse",
+        "uri": "https://fef.msud01.manage.microsoft.com/ReportingService/DataWarehouseFEService",
+        "providerResourceId": "2772ef03-ea2e-400d-8114-6d1be6558493"
+    },
+    {
+        "id": "5ae4c117-ed8b-4bb5-b38a-07108ee6eb5c",
+        "deletedDateTime": null,
+        "capability": "DataWarehouseBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DataWarehouseBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/ReportingService/DataWarehouseFEService",
+        "providerResourceId": "57bae6e4-84fd-4ca3-b840-9265bb27679f"
+    },
+    {
+        "id": "137a027b-95cb-4240-aef4-8ad4ed084010",
+        "deletedDateTime": null,
+        "capability": "DepFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DepFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Dep/DepFEService",
+        "providerResourceId": "dd6a823d-9a9a-419e-bb01-ec79f03f288e"
+    },
+    {
+        "id": "a448df04-6b65-4bf8-a7d3-f2bf238729d1",
+        "deletedDateTime": null,
+        "capability": "DepFEServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DepFEServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/Dep/DepFEService",
+        "providerResourceId": "d5d29808-b339-4374-9227-185dace53db8"
+    },
+    {
+        "id": "da14e929-f870-4378-a9a5-322f24cbb681",
+        "deletedDateTime": null,
+        "capability": "Device",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "Device",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceFE/StatelessDeviceFEService",
+        "providerResourceId": "04766c26-3988-42fd-b041-15812a697aff"
+    },
+    {
+        "id": "7f0c7aa5-940c-406a-a092-532bff65e69d",
+        "deletedDateTime": null,
+        "capability": "DeviceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/DeviceFE/StatelessDeviceFEService",
+        "providerResourceId": "1be817ff-874c-4db2-934e-c48e7c92e8b1"
+    },
+    {
+        "id": "953ebcb2-0ac7-460e-b580-6c8118437b22",
+        "deletedDateTime": null,
+        "capability": "DeviceCheckin",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceCheckin",
+        "uri": "https://fef.msud01.manage.microsoft.com/DeviceCheckin",
+        "providerResourceId": "c225d0f8-b12a-4dac-9d59-12d94a4c45cb"
+    },
+    {
+        "id": "103aa558-e126-48b7-a9ca-8971054e4911",
+        "deletedDateTime": null,
+        "capability": "DeviceCheckin_Canary",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceCheckin_Canary",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/DeviceCheckinRoutingService/DeviceCheckin",
+        "providerResourceId": "6c6494aa-af7c-45b3-aad6-212880045224"
+    },
+    {
+        "id": "f0170605-865c-4f39-91f1-f3ba7534a24e",
+        "deletedDateTime": null,
+        "capability": "DeviceConfiguration",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceConfiguration",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceConfiguration/StatelessDeviceConfigurationFEService",
+        "providerResourceId": "852a4ced-ffb3-432f-a30d-0bbbf0185444"
+    },
+    {
+        "id": "d69e2fcc-6bd6-4316-b5b3-2c252e76a662",
+        "deletedDateTime": null,
+        "capability": "DeviceConfigurationBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceConfigurationBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessDeviceConfigurationFEService",
+        "providerResourceId": "6281f1e3-19ae-4a34-ac94-f7450c323e56"
+    },
+    {
+        "id": "76f0db8b-5c24-4138-89b2-bc7d616b4b75",
+        "deletedDateTime": null,
+        "capability": "DeviceEnrollment",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceEnrollment",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Wcs/StatelessOnboardingService",
+        "providerResourceId": "0d9c5414-fc5e-426d-9a2a-5f060d629a45"
+    },
+    {
+        "id": "70a266a4-e851-40e3-9156-4bca23d06160",
+        "deletedDateTime": null,
+        "capability": "DeviceEnrollmentBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceEnrollmentBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessOnboardingService",
+        "providerResourceId": "03a9e901-bb3a-4ca5-9be3-06b5934c99a7"
+    },
+    {
+        "id": "c87556ef-7e42-407a-b26e-a52aa74e5a02",
+        "deletedDateTime": null,
+        "capability": "DeviceEnrollmentFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceEnrollmentFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceEnrollmentFE/StatelessDeviceEnrollmentFEService",
+        "providerResourceId": "3d028682-c3b2-483c-a802-a7702bb5fa51"
+    },
+    {
+        "id": "10c91d10-14b2-4636-9968-8d332b2ef9f3",
+        "deletedDateTime": null,
+        "capability": "DeviceEnrollmentFEServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceEnrollmentFEServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/DeviceEnrollmentFE/StatelessDeviceEnrollmentFEService",
+        "providerResourceId": "7e8b6e09-e39f-4a53-a9d0-63bd85c14163"
+    },
+    {
+        "id": "ce153ea3-84e0-4a33-967a-9aec3a91b11f",
+        "deletedDateTime": null,
+        "capability": "DeviceManagementIntent",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceManagementIntent",
+        "uri": "https://fef.msud01.manage.microsoft.com/DeviceManagementIntent/DeviceManagementIntentGatewayService/Gateway/DeviceManagementIntentService",
+        "providerResourceId": "03f47fc7-3349-4e79-928e-5389e5c4ed7a"
+    },
+    {
+        "id": "bb57229f-4343-466c-aebb-2a3698ef4718",
+        "deletedDateTime": null,
+        "capability": "DeviceManagementIntentGatewayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceManagementIntentGatewayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceManagementIntent/DeviceManagementIntentService",
+        "providerResourceId": "958b645d-7661-4052-aec7-cdb55cf126d5"
+    },
+    {
+        "id": "d914f2f1-0e08-47f2-80a0-bdec5508ede7",
+        "deletedDateTime": null,
+        "capability": "DeviceManagementIntentGatewayServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceManagementIntentGatewayServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/DeviceManagementIntent/DeviceManagementIntentGatewayService",
+        "providerResourceId": "10afed53-f0f0-478e-a8a1-8080779a1f22"
+    },
+    {
+        "id": "9f6db3d2-4bef-45bd-be4d-7da839c3e840",
+        "deletedDateTime": null,
+        "capability": "DeviceProvisioningAdminService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DeviceProvisioningAdminService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Dep/DeviceProvisioningAdminService",
+        "providerResourceId": "caf4b68f-793d-457a-8c21-e5065ecbb1c4"
+    },
+    {
+        "id": "5c17c848-605f-4935-a674-5a3be1b444cf",
+        "deletedDateTime": null,
+        "capability": "DiagnosticService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DiagnosticService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DiagnosticService/StatelessDiagnosticService",
+        "providerResourceId": "1faf959c-a9ed-4d9f-ae64-75b655f287ea"
+    },
+    {
+        "id": "0200987b-4606-4660-8cc4-a4863b4749dc",
+        "deletedDateTime": null,
+        "capability": "DiagnosticServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DiagnosticServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/DiagnosticService/StatelessDiagnosticService",
+        "providerResourceId": "73dda844-ef12-48c1-b42f-c5562d55d675"
+    },
+    {
+        "id": "e431ee3b-1fef-4a71-8af2-17dc095b9c21",
+        "deletedDateTime": null,
+        "capability": "DiscoveryService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DiscoveryService",
+        "uri": "https://manage.microsoft.com/EnrollmentServer/Discovery.svc",
+        "providerResourceId": "b57dda70-336a-4d14-9ba3-2e981fce1982"
+    },
+    {
+        "id": "485c26d9-38b4-4b94-a5a4-ba79acfeef76",
+        "deletedDateTime": null,
+        "capability": "DocumentDistributionService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "DocumentDistributionService",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessDocumentDistributionService",
+        "providerResourceId": "22c069a9-0cff-4e88-99d8-d0f56dfba231"
+    },
+    {
+        "id": "db118ce7-2828-4b8b-98da-f3a4425c0b54",
+        "deletedDateTime": null,
+        "capability": "EBookMetadata",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EBookMetadata",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AppleVPP/StatelessEBookMetadataFEService",
+        "providerResourceId": "b070a3f0-0dcf-4025-9f45-2840d4915679"
+    },
+    {
+        "id": "3806cfb9-fb2b-4840-83bb-66f7cb726a95",
+        "deletedDateTime": null,
+        "capability": "EBookMetadataBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EBookMetadataBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/AppleVPP/StatelessEBookMetadataFEService",
+        "providerResourceId": "4736abe1-ea0e-4e9a-bfac-2f8c70f1d193"
+    },
+    {
+        "id": "a5b0e206-9da7-4a4d-b773-ba30c2492dbc",
+        "deletedDateTime": null,
+        "capability": "EmbeddedSIMAdminService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EmbeddedSIMAdminService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/EmbeddedSIM/EmbeddedSIMService",
+        "providerResourceId": "d23132fa-3af3-4454-82f5-a1b3e69d3cd8"
+    },
+    {
+        "id": "a0bfaa9c-f2a8-441f-a583-384dafed1245",
+        "deletedDateTime": null,
+        "capability": "EmbeddedSIMAdminServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EmbeddedSIMAdminServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/EmbeddedSIM/EmbeddedSIMGatewayService/Gateway/EmbeddedSIMService",
+        "providerResourceId": "2d402308-d0e3-49c4-a879-d6aa712e35f7"
+    },
+    {
+        "id": "cf3fe8ac-a807-466a-9716-b270eae343c2",
+        "deletedDateTime": null,
+        "capability": "EmbeddedSIMGatewayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EmbeddedSIMGatewayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/EmbeddedSIM/EmbeddedSIMService",
+        "providerResourceId": "c7f54c05-75a2-440e-8dcf-1a95c38dc25c"
+    },
+    {
+        "id": "d73560ed-83eb-47af-936d-f22cd3ca0bd0",
+        "deletedDateTime": null,
+        "capability": "EmbeddedSIMGatewayServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EmbeddedSIMGatewayServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/EmbeddedSIM/EmbeddedSIMGatewayService",
+        "providerResourceId": "8ab0e016-40d3-45c3-bd65-5bb719aff50f"
+    },
+    {
+        "id": "cfe33ee9-2b48-40d0-b63b-78ab12548234",
+        "deletedDateTime": null,
+        "capability": "EndpointProtection",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EndpointProtection",
+        "uri": "https://fef.msud01.manage.microsoft.com/IntuneDefenderServices/StatelessDefenderFEService",
+        "providerResourceId": "f3fe1d9e-55f4-41b3-a4b0-0d6a7b71ecab"
+    },
+    {
+        "id": "37160ff0-0fea-455a-a7ed-6d7a29bf05bf",
+        "deletedDateTime": null,
+        "capability": "EnrollmentSTS",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EnrollmentSTS",
+        "uri": "https://msud01.manage.microsoft.com/AgentEnrollmentSecurityTokenService/IWSTrust.svc",
+        "providerResourceId": "1fc367c4-3ccf-4fb8-bfea-98cbe9ceb338"
+    },
+    {
+        "id": "fb77f78e-4a24-4903-826c-01a756430c7f",
+        "deletedDateTime": null,
+        "capability": "EnrollmentService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EnrollmentService",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService",
+        "providerResourceId": "a21081b8-daef-47fe-a761-f45e5fb68457"
+    },
+    {
+        "id": "543b63ec-3cc2-4c1c-8ef0-9cddb45b9cb4",
+        "deletedDateTime": null,
+        "capability": "EpmGraphApiService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EpmGraphApiService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GPAnalytics/EpmGraphApiService",
+        "providerResourceId": "76c48d04-98a9-4b6b-9d0d-1a83b679c343"
+    },
+    {
+        "id": "d30760a7-84d8-4e45-a11a-88b96751f9d6",
+        "deletedDateTime": null,
+        "capability": "ErrorEventWebService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ErrorEventWebService",
+        "uri": "http://msud01.manage.microsoft.com/ErrorEventWebService/ErrorEventWebService.svc",
+        "providerResourceId": "72cc42f9-e6ea-47b5-9f4e-041f10dd752d"
+    },
+    {
+        "id": "d2b10900-f87d-43ef-87bd-9e5c8acff68c",
+        "deletedDateTime": null,
+        "capability": "EventWebService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "EventWebService",
+        "uri": "https://msud01.manage.microsoft.com/EventWebService/EventWebService.svc",
+        "providerResourceId": "0d2f2577-c97f-4748-bd91-9041c25bb04d"
+    },
+    {
+        "id": "a4cc03cc-2c12-4d17-a8db-03721b11721f",
+        "deletedDateTime": null,
+        "capability": "ExchangeGatewayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ExchangeGatewayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessExchangeGatewayService",
+        "providerResourceId": "32280f9d-a53f-42d3-ae22-47964e6ea075"
+    },
+    {
+        "id": "b0bd588c-13a6-4cd7-9dff-33456e79d46f",
+        "deletedDateTime": null,
+        "capability": "ExchangeGatewayServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ExchangeGatewayServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessExchangeGatewayService",
+        "providerResourceId": "e7fc5e06-6c0b-4204-afb7-2cd885402715"
+    },
+    {
+        "id": "9819e19c-7f59-45d7-83aa-6f002fceb979",
+        "deletedDateTime": null,
+        "capability": "ExchangeIncomingGateway",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ExchangeIncomingGateway",
+        "uri": "https://msud01.manage.microsoft.com/ExchangeIncomingGateway/GatewayService.svc",
+        "providerResourceId": "f0f81774-a5e4-44d5-b3c3-597c24f8bf7c"
+    },
+    {
+        "id": "ff1d0edd-ff73-400f-8e03-b87a8347918e",
+        "deletedDateTime": null,
+        "capability": "FEF_URL",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "FEF_URL",
+        "uri": "https://fef.msud01.manage.microsoft.com/",
+        "providerResourceId": "14c43a02-ec69-45c2-8f3d-94a58ecb4095"
+    },
+    {
+        "id": "f25295ca-ef93-4c14-8d49-b50db9f079f8",
+        "deletedDateTime": null,
+        "capability": "FEIIS_URL",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "FEIIS_URL",
+        "uri": "https://fei.msud01.manage.microsoft.com/",
+        "providerResourceId": "7ea6dad1-40e4-4cf7-ae0e-19d75020652c"
+    },
+    {
+        "id": "36b7fc3e-f35e-48fe-93a8-c9addb86c5e9",
+        "deletedDateTime": null,
+        "capability": "FencingGatewayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "FencingGatewayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Fencing/FencingSignalService",
+        "providerResourceId": "b68db34e-9953-4ca8-bc12-1b45d1272c84"
+    },
+    {
+        "id": "080894f7-4ab3-4ff4-9ff9-969fde5fb9e8",
+        "deletedDateTime": null,
+        "capability": "FencingGatewayServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "FencingGatewayServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/Fencing/FencingGatewayService",
+        "providerResourceId": "3cd453c8-61a9-45e0-8478-296a44e8ca7e"
+    },
+    {
+        "id": "92f540b8-2561-416a-a6c3-bd2be8be4492",
+        "deletedDateTime": null,
+        "capability": "FencingSignalService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "FencingSignalService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Fencing/FencingSignalService",
+        "providerResourceId": "a1127a4b-cac0-4aa6-a8f2-da3629e5da35"
+    },
+    {
+        "id": "1b9ee7c8-9864-4465-b6a6-f6d323c7ad72",
+        "deletedDateTime": null,
+        "capability": "ForceUpdateEndpoint",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ForceUpdateEndpoint",
+        "uri": "https://fef.msud01.manage.microsoft.com/ForceUpdateEndpoint",
+        "providerResourceId": "5cb2f907-cf66-4c44-8c43-a337106e9acd"
+    },
+    {
+        "id": "fc88c6b6-f5af-4f9f-b2bd-45bcd78dd53d",
+        "deletedDateTime": null,
+        "capability": "GPAnalyticsService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "GPAnalyticsService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GPAnalytics/StatelessGPAnalyticsService",
+        "providerResourceId": "d97d928b-7f46-460f-8f0f-50ea183e2e5e"
+    },
+    {
+        "id": "e07aff4a-e993-475e-8a1c-d744f49d7d54",
+        "deletedDateTime": null,
+        "capability": "GnTGraphService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "GnTGraphService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GnT/GnTGraphService",
+        "providerResourceId": "d7f0d9f5-c886-47f3-a0f8-005b6f64957c"
+    },
+    {
+        "id": "9120ec95-fd5b-47f9-9e68-8fb16f9622fb",
+        "deletedDateTime": null,
+        "capability": "GroupPolicyGatewayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "GroupPolicyGatewayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GroupPolicy/GroupPolicyAdminService",
+        "providerResourceId": "bb57edf0-72e0-467c-be77-24ff90821edf"
+    },
+    {
+        "id": "740740d0-fd2e-4aae-8044-034c87fa6b4f",
+        "deletedDateTime": null,
+        "capability": "GroupPolicyGatewayServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "GroupPolicyGatewayServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/GroupPolicy/GroupPolicyGatewayService",
+        "providerResourceId": "c33ee74c-ca48-4cbb-aca6-c438bef721a1"
+    },
+    {
+        "id": "42831abc-70a6-48e0-9622-1df49f31e70b",
+        "deletedDateTime": null,
+        "capability": "HttpsErrorEventWebService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "HttpsErrorEventWebService",
+        "uri": "https://msud01.manage.microsoft.com/ErrorEventWebService/ErrorEventWebService.svc",
+        "providerResourceId": "987df1c5-dc26-4d1c-acb4-cfb6bbd4ab51"
+    },
+    {
+        "id": "c56e24fd-d135-46de-8ea4-d3f0d3084d15",
+        "deletedDateTime": null,
+        "capability": "HybridConnectorService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "HybridConnectorService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Hybrid/StatelessConnectorService/",
+        "providerResourceId": "9b023286-5e80-47ec-b082-30c4007c28ff"
+    },
+    {
+        "id": "b735eb0e-4777-47a4-821e-44216305885f",
+        "deletedDateTime": null,
+        "capability": "ICSGraphService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ICSGraphService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ICS/ICSGraphService",
+        "providerResourceId": "c09d8fcc-5d43-4d9e-a199-40ff3238c2c7"
+    },
+    {
+        "id": "e39f06cf-64c1-405b-8723-90bc75a63f91",
+        "deletedDateTime": null,
+        "capability": "IWPortalAllEbooksPage",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "IWPortalAllEbooksPage",
+        "uri": "https://portal.manage.microsoft.com/ebooks",
+        "providerResourceId": "3d16a69e-5cea-4cf7-bdcc-36b92dfe99c8"
+    },
+    {
+        "id": "2f481fdc-6a95-4a07-954d-ba242a6b8c46",
+        "deletedDateTime": null,
+        "capability": "IWPortalExchangeActivateDevice",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "IWPortalExchangeActivateDevice",
+        "uri": "https://portal.manage.microsoft.com/devices/exchangeActivateDevice",
+        "providerResourceId": "87f59d22-ce73-4cd2-840c-fd5b75c9cf80"
+    },
+    {
+        "id": "61fc8ac9-107f-4357-972a-e31c4d4194e1",
+        "deletedDateTime": null,
+        "capability": "IWPortalExchangeActivationDetailsPage",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "IWPortalExchangeActivationDetailsPage",
+        "uri": "https://portal.manage.microsoft.com/enrollment/getExchangeActivationDetails",
+        "providerResourceId": "3779980c-c866-48e6-9b3c-4bad8a62c1bf"
+    },
+    {
+        "id": "968901c6-9885-4ab6-bc1a-478e39b1c60e",
+        "deletedDateTime": null,
+        "capability": "IWPortalSetActiveDevice",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "IWPortalSetActiveDevice",
+        "uri": "https://portal.manage.microsoft.com/enrollment/setActiveDevice",
+        "providerResourceId": "68676cbb-ab06-4af8-86c0-eccf3b6a389e"
+    },
+    {
+        "id": "23e06d58-182f-410f-9df8-c6751b36ef5d",
+        "deletedDateTime": null,
+        "capability": "IWPortalUdaClaimUrl",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "IWPortalUdaClaimUrl",
+        "uri": "https://portal.manage.microsoft.com/devices/link",
+        "providerResourceId": "4c4c3aac-c303-4944-a8c3-b5605f7cd74d"
+    },
+    {
+        "id": "7bdfc279-9973-48cd-965f-a18e9aff2c70",
+        "deletedDateTime": null,
+        "capability": "IWService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "IWService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/IWService/StatelessIWService",
+        "providerResourceId": "38dcc0bd-bd30-4d11-b3ef-628bc0489280"
+    },
+    {
+        "id": "24d20696-8b74-4de8-bd3b-a05a65390aa1",
+        "deletedDateTime": null,
+        "capability": "IWServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "IWServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessIWService",
+        "providerResourceId": "9838a1c2-fcd1-46d8-ba46-e81364f3f9b9"
+    },
+    {
+        "id": "9d3e69dd-d68b-4775-9102-beb97694fdc4",
+        "deletedDateTime": null,
+        "capability": "ImportPFXGatewayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ImportPFXGatewayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/StatelessImportPFXService",
+        "providerResourceId": "f73d6f0e-2b8e-453f-81ff-d71a6c11bd75"
+    },
+    {
+        "id": "5bf08500-3818-4139-bd1c-6824f868a98f",
+        "deletedDateTime": null,
+        "capability": "ImportPFXGatewayServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ImportPFXGatewayServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/RACerts/ImportPFXGatewayService/Gateway/StatelessImportPFXService",
+        "providerResourceId": "9c4a1a0b-3f83-4f1c-9fd1-920ba99b8aec"
+    },
+    {
+        "id": "50116e27-a9e9-456c-b857-3836e8b1519d",
+        "deletedDateTime": null,
+        "capability": "InventoryUpload",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "InventoryUpload",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceDataUpload/StatelessDeviceDataUploadService",
+        "providerResourceId": "83717582-3086-4367-9908-cea25067b09c"
+    },
+    {
+        "id": "44cf4134-ff43-431a-a15e-e45809413202",
+        "deletedDateTime": null,
+        "capability": "KeyService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "KeyService",
+        "uri": "https://manage.microsoft.com/KeyService/KeyServiceAgent.svc",
+        "providerResourceId": "ad367dab-a2f2-4549-a0f0-d45e39b6b0f3"
+    },
+    {
+        "id": "24b94131-b143-42a3-b05d-896dd00013ee",
+        "deletedDateTime": null,
+        "capability": "LinuxDeviceCheckinService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "LinuxDeviceCheckinService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/LinuxMdm/LinuxDeviceCheckinService",
+        "providerResourceId": "491a5d24-b216-4c3f-a819-a5d152d08738"
+    },
+    {
+        "id": "7a2f3ba5-a899-4a76-a53b-332b01fcebfd",
+        "deletedDateTime": null,
+        "capability": "LinuxEnrollmentService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "LinuxEnrollmentService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/LinuxMDM/LinuxEnrollmentService",
+        "providerResourceId": "e5b950e6-96b7-423b-99a3-76d4039d8a76"
+    },
+    {
+        "id": "d87d2546-8a17-475a-a42c-6cc4a42bde4c",
+        "deletedDateTime": null,
+        "capability": "LocationServiceService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "LocationServiceService",
+        "uri": "https://manage.microsoft.com/LocationService/LocationService.svc",
+        "providerResourceId": "595918ca-8858-4c07-81d8-aab64a4c2b9b"
+    },
+    {
+        "id": "e13e205c-311e-49ab-bf96-fdbf6b592ecb",
+        "deletedDateTime": null,
+        "capability": "MAMAdminFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MAMAdminFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/MAMAdmin/MAMAdminFEService",
+        "providerResourceId": "3bdf5a53-7597-4b48-9f65-389ee28864c8"
+    },
+    {
+        "id": "a2daaf0d-f199-42a3-b1b4-58c06161e5f5",
+        "deletedDateTime": null,
+        "capability": "MAMAdminFEServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MAMAdminFEServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/MAMAdmin/MAMAdminFEService",
+        "providerResourceId": "8b1d74d7-aea4-44dd-95d7-3f29cf017426"
+    },
+    {
+        "id": "5dd033de-09cc-487c-86c6-f6fc29c30cdf",
+        "deletedDateTime": null,
+        "capability": "MSUName",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MSUName",
+        "uri": "MSUD01",
+        "providerResourceId": "5e1e7731-d7ab-4b77-9c4a-5584eafff9a6"
+    },
+    {
+        "id": "144e5b36-9ae5-481e-8af8-b0b618e1138d",
+        "deletedDateTime": null,
+        "capability": "MSUPortalRoot",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MSUPortalRoot",
+        "uri": "https://portal.manage.microsoft.com/",
+        "providerResourceId": "4925b020-5d82-48bc-b6d7-86b387700994"
+    },
+    {
+        "id": "08a674fd-20c2-4c5f-9d90-51cf287be354",
+        "deletedDateTime": null,
+        "capability": "MSU_URL",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MSU_URL",
+        "uri": "https://msud01.manage.microsoft.com/",
+        "providerResourceId": "e3b33764-5521-4280-9ad8-dd4f9e383dcc"
+    },
+    {
+        "id": "f14136f4-9c03-45bc-b36d-77e93cfe32a4",
+        "deletedDateTime": null,
+        "capability": "MicrosoftTunnelService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MicrosoftTunnelService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/MobileAccess/MicrosoftTunnelService",
+        "providerResourceId": "e6c5aacf-529b-4065-ba77-755a1066eb8d"
+    },
+    {
+        "id": "280592fa-a97e-4715-9a39-ad7206e4cd08",
+        "deletedDateTime": null,
+        "capability": "MobileAccessService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MobileAccessService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/MobileAccess/MobileAccessService",
+        "providerResourceId": "97846e7f-dedd-4af6-8f58-27cef7c03ad8"
+    },
+    {
+        "id": "86ae72e3-fb48-4bbb-bccf-f6f5813cf8e5",
+        "deletedDateTime": null,
+        "capability": "MobileAccessServiceAgents",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MobileAccessServiceAgents",
+        "uri": "https://agents.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/MobileAccess/MobileAccessService",
+        "providerResourceId": "e7296ea6-dc65-44f4-9c95-8293cbb00515"
+    },
+    {
+        "id": "0a51c607-bfd2-4451-960d-4639d72f67a1",
+        "deletedDateTime": null,
+        "capability": "MobilePortalAllAppsPage",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MobilePortalAllAppsPage",
+        "uri": "https://portal.manage.microsoft.com/apps",
+        "providerResourceId": "ceb035f7-4632-4500-a37a-328ded035921"
+    },
+    {
+        "id": "ec948f2f-e185-42be-a076-42b6c7d83d7d",
+        "deletedDateTime": null,
+        "capability": "MobilePortalRoot",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MobilePortalRoot",
+        "uri": "https://portal.manage.microsoft.com/",
+        "providerResourceId": "cb5e33dc-10c3-4ef9-9ee4-d56bac82eb0d"
+    },
+    {
+        "id": "3d848e36-d93e-4f5e-b312-4694a4195c9b",
+        "deletedDateTime": null,
+        "capability": "MultiDevicePivotService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "MultiDevicePivotService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Pivot/MultiDevicePivotService",
+        "providerResourceId": "c6d3350d-2ae6-4043-82e8-5d26bbdceff3"
+    },
+    {
+        "id": "be09bbe9-2e22-4fb8-91a2-96f4c35ce9d6",
+        "deletedDateTime": null,
+        "capability": "NACAPIService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "NACAPIService",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessNACService",
+        "providerResourceId": "67f2d287-21bd-482b-9fdd-672be732729c"
+    },
+    {
+        "id": "78040ee8-6a8d-49eb-bad9-869fac9ddc78",
+        "deletedDateTime": null,
+        "capability": "NACAPIServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "NACAPIServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessNACService",
+        "providerResourceId": "a5d7e199-5ba0-48d1-adba-b4f7c91e8c78"
+    },
+    {
+        "id": "255cea63-a768-48b6-8dc4-f4da0bfee28c",
+        "deletedDateTime": null,
+        "capability": "NDESConnectorService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "NDESConnectorService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Hybrid/StatelessConnectorService/",
+        "providerResourceId": "cba5b375-d360-4264-8f47-b3c3d7ba956f"
+    },
+    {
+        "id": "2e1a1b34-8db8-46af-8848-6707b5f1aa67",
+        "deletedDateTime": null,
+        "capability": "NotificationMessageTemplate",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "NotificationMessageTemplate",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Wcs/StatelessNotificationFEService",
+        "providerResourceId": "005e9a93-7ffe-4f1b-8e40-c6aeabeadb96"
+    },
+    {
+        "id": "4efb9bd2-ad51-4437-ab01-5097d17a548e",
+        "deletedDateTime": null,
+        "capability": "NotificationMessageTemplateBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "NotificationMessageTemplateBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessNotificationFEService",
+        "providerResourceId": "50c19f8a-b92a-4649-97e3-9d7aa7c5066f"
+    },
+    {
+        "id": "8030fef0-8fa0-4486-b37c-3779b292b0ba",
+        "deletedDateTime": null,
+        "capability": "NotificationPollingService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "NotificationPollingService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RTNService/NotificationPollingService",
+        "providerResourceId": "5a68e2d0-5b37-4709-9db3-ec7c53ee874d"
+    },
+    {
+        "id": "57cb43bf-ec3e-4099-98d1-7130bde33c17",
+        "deletedDateTime": null,
+        "capability": "OSProvisioningGraphService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "OSProvisioningGraphService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/OSProvisioning/OSProvisioningGraphService",
+        "providerResourceId": "b6996d3c-0cb2-4de3-9a8a-eccd9e78b4f3"
+    },
+    {
+        "id": "ba1119ba-1d70-4fe6-b371-2d9205375345",
+        "deletedDateTime": null,
+        "capability": "OSRecoveryService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "OSRecoveryService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/OSProvisioning/OSRecoveryService",
+        "providerResourceId": "1e640b9e-e591-40f4-ac12-d1847db98e78"
+    },
+    {
+        "id": "0e92432d-c8fd-4bd0-924a-e5ea832f2241",
+        "deletedDateTime": null,
+        "capability": "OrganizationalMessagesService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "OrganizationalMessagesService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerIntegrations/OrganizationalMessagesService",
+        "providerResourceId": "7773652d-c93b-4401-97d9-6148a7081f1f"
+    },
+    {
+        "id": "f9f245f4-3d46-4821-a99a-1cb2e3f8a24f",
+        "deletedDateTime": null,
+        "capability": "PCPortalRoot",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "PCPortalRoot",
+        "uri": "https://portal.manage.microsoft.com/",
+        "providerResourceId": "f9ce7849-73d4-4fa7-bacd-bf6e9ad4eb2e"
+    },
+    {
+        "id": "31198ad1-9dac-4dee-91bc-60d8f663a8df",
+        "deletedDateTime": null,
+        "capability": "PartnerComplianceService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "PartnerComplianceService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Compliance/PartnerComplianceService",
+        "providerResourceId": "1cfacb92-8d3a-43ed-af34-88994414d449"
+    },
+    {
+        "id": "03b32959-9cdd-4a3f-94f1-9a8a4bd63b31",
+        "deletedDateTime": null,
+        "capability": "PartnerDeviceDataSyncService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "PartnerDeviceDataSyncService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerAPI/StatelessPartnerDeviceDataSyncService",
+        "providerResourceId": "c304cae7-8d07-42dc-a82f-af1055e0b56a"
+    },
+    {
+        "id": "01687c0f-cb16-4055-9480-6adbcbdd5e9f",
+        "deletedDateTime": null,
+        "capability": "PartnerDeviceDataSyncServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "PartnerDeviceDataSyncServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerAPI/StatelessPartnerDeviceDataSyncService",
+        "providerResourceId": "6591235b-52a7-49a5-9273-45531a2ea542"
+    },
+    {
+        "id": "405d17b2-0e3e-4ba4-a4b1-3d10a1c98539",
+        "deletedDateTime": null,
+        "capability": "PartnerTenantDataSyncService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "PartnerTenantDataSyncService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerAPI/StatelessPartnerTenantDataSyncService",
+        "providerResourceId": "7a6cbbb6-f508-40df-adb2-ed155d114fcf"
+    },
+    {
+        "id": "3766bfd1-2953-4312-8a84-ad8f9a7b6133",
+        "deletedDateTime": null,
+        "capability": "PartnerTenantDataSyncServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "PartnerTenantDataSyncServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerAPI/StatelessPartnerTenantDataSyncService",
+        "providerResourceId": "8549e73e-25ed-46b4-849d-ebe6ab1aa30c"
+    },
+    {
+        "id": "f88ce91e-a792-4c02-a200-dc21762d43e6",
+        "deletedDateTime": null,
+        "capability": "PkiConnectorFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "PkiConnectorFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/StatelessPkiConnectorService",
+        "providerResourceId": "8a29ed99-8710-4014-949f-ba0f8334e624"
+    },
+    {
+        "id": "72fd1790-b0c3-4179-9156-a5c9bbc3f18e",
+        "deletedDateTime": null,
+        "capability": "PolicyListingService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "PolicyListingService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GPAnalytics/PolicyListingService",
+        "providerResourceId": "7b8614fc-ef54-465f-a9bc-9d276129d402"
+    },
+    {
+        "id": "28914e73-7d93-4e44-b983-a1c415369189",
+        "deletedDateTime": null,
+        "capability": "PolicySetService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "PolicySetService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/GnT/StatelessPayloadLinkingService",
+        "providerResourceId": "eb68505c-22de-40fd-87a9-af3129be7fc6"
+    },
+    {
+        "id": "f47e3189-ba2c-4729-b718-d3ee4d316499",
+        "deletedDateTime": null,
+        "capability": "PowerLiftService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "PowerLiftService",
+        "uri": "https://powerlift-frontdesk.acompli.net",
+        "providerResourceId": "bc86bde1-ef53-4a85-b551-8aad6a7e7642"
+    },
+    {
+        "id": "8674edbd-a750-4ef0-85c1-2d802ee3a137",
+        "deletedDateTime": null,
+        "capability": "QueryBrokerService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "QueryBrokerService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DataInfra/QueryBrokerFSIService",
+        "providerResourceId": "c360c10e-9381-4ba2-9cc8-af1b6953ac17"
+    },
+    {
+        "id": "b2d79d5b-c09a-421d-af72-fd0f1fdc409b",
+        "deletedDateTime": null,
+        "capability": "RAConnectorsTelemetryService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "RAConnectorsTelemetryService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/RAConnectorsTelemetryService",
+        "providerResourceId": "fe11edb2-c652-4bf5-9b1e-636b42e31874"
+    },
+    {
+        "id": "e8ac8d44-da3d-4baf-bd31-7d9a08fbde44",
+        "deletedDateTime": null,
+        "capability": "RAODJPlusFEGatewayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "RAODJPlusFEGatewayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RAODJPlus/StatelessODJService",
+        "providerResourceId": "de3041e9-2ef3-4cfc-8799-eaaf1da26ec5"
+    },
+    {
+        "id": "e75296e7-4b3b-451f-95f6-5bf43a4a64ca",
+        "deletedDateTime": null,
+        "capability": "RAODJPlusFEGatewayService_FEF",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "RAODJPlusFEGatewayService_FEF",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RAODJPlus/StatelessODJService",
+        "providerResourceId": "e584e573-ed1a-4e62-8656-39fe35ee72a5"
+    },
+    {
+        "id": "95d46d2e-27f9-4ad5-8e6f-d6e4f61c07a8",
+        "deletedDateTime": null,
+        "capability": "RAPolicyFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "RAPolicyFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/StatelessRAPolicyService",
+        "providerResourceId": "c1a409c7-f052-477e-b736-09b049f38612"
+    },
+    {
+        "id": "05156e06-864d-4edb-8aea-08e440709886",
+        "deletedDateTime": null,
+        "capability": "Region",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "Region",
+        "uri": "OC",
+        "providerResourceId": "31a2b6cc-7d5b-4b26-b2f8-7f3a9e4b2776"
+    },
+    {
+        "id": "8cfe1c72-8497-4145-902f-00679aac8a31",
+        "deletedDateTime": null,
+        "capability": "RemoteAssistanceService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "RemoteAssistanceService",
+        "uri": "https://msud01.manage.microsoft.com/RemoteAssistanceService/RemoteAssistanceService.svc",
+        "providerResourceId": "cbe02f2d-3a33-42a2-a282-c984351a26d4"
+    },
+    {
+        "id": "76e9b656-3213-4e30-b81d-7d8fc5473253",
+        "deletedDateTime": null,
+        "capability": "ReportingExperienceService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ReportingExperienceService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ReportingService/ReportingExperienceService",
+        "providerResourceId": "fddef275-3cd0-474d-af6d-9c7f808d92fa"
+    },
+    {
+        "id": "09a1cd56-9b08-4d65-a207-0a42f4cf191a",
+        "deletedDateTime": null,
+        "capability": "ReportingFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ReportingFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ReportingService/StatelessReportingFEService",
+        "providerResourceId": "0a91a93e-bb84-49d0-a1d6-11f4bd47f262"
+    },
+    {
+        "id": "7d27df9c-89c5-4e7a-970b-99c3d15081be",
+        "deletedDateTime": null,
+        "capability": "RoleAdministration",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "RoleAdministration",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RBAC/StatelessRoleAdministrationFEService",
+        "providerResourceId": "cac892b1-062c-489a-a45c-61320e2530b2"
+    },
+    {
+        "id": "07386af1-f0b3-4ee8-ade9-9f7a7fc35141",
+        "deletedDateTime": null,
+        "capability": "RoleAdministrationBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "RoleAdministrationBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessRoleAdministrationFEService",
+        "providerResourceId": "3ac071e2-8f19-4bef-8895-8e4116939912"
+    },
+    {
+        "id": "e29c0891-4392-4cf1-8c5e-61400f5c893b",
+        "deletedDateTime": null,
+        "capability": "SCCMConnector",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SCCMConnector",
+        "uri": "https://msud01.manage.microsoft.com/SCCMConnectorService/SccmConnectorService.svc",
+        "providerResourceId": "e823ddc0-6382-485f-8a72-45ac8949c3fe"
+    },
+    {
+        "id": "d89f2841-ef69-4cbd-afdf-b9eacac172fd",
+        "deletedDateTime": null,
+        "capability": "SCCMConnectorService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SCCMConnectorService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Hybrid/StatelessConnectorService/",
+        "providerResourceId": "4d731aa8-7794-4b4b-ac8e-2b3bb6fb9f25"
+    },
+    {
+        "id": "95041250-88c3-4652-9449-2d8adac77d1f",
+        "deletedDateTime": null,
+        "capability": "SCCMUserSyncService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SCCMUserSyncService",
+        "uri": "https://msud01.manage.microsoft.com/MSUSCCMUserEnable/MSUSccmUserEnable.svc",
+        "providerResourceId": "24d23435-be35-4888-8c2d-6aad049853d4"
+    },
+    {
+        "id": "2a051380-af89-49b4-a4fa-8a370ae2fe97",
+        "deletedDateTime": null,
+        "capability": "ScepRequestValidationFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ScepRequestValidationFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RACerts/StatelessScepRequestValidationService",
+        "providerResourceId": "103641f5-a5c1-48b5-9367-adc309576a58"
+    },
+    {
+        "id": "cc7fe602-826a-44bc-99a8-afb33cbdd039",
+        "deletedDateTime": null,
+        "capability": "SelfUpdateService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SelfUpdateService",
+        "uri": "http://msud01.manage.microsoft.com/SelfUpdate",
+        "providerResourceId": "71d35e3a-2b56-49eb-ba48-b31500c770a7"
+    },
+    {
+        "id": "7ed61fce-6b6a-445e-b9b2-73b7ef76ba59",
+        "deletedDateTime": null,
+        "capability": "ServerAuthLocationServiceService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ServerAuthLocationServiceService",
+        "uri": "https://manage.microsoft.com/ServerAuthLocationService/ServerAuthLocationService.svc",
+        "providerResourceId": "be13c622-cf82-4335-bb37-b5e5587ea4d1"
+    },
+    {
+        "id": "b416fe44-97c1-4467-893d-0422d21d5278",
+        "deletedDateTime": null,
+        "capability": "ServiceNowConnector",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ServiceNowConnector",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ReportingService/ServiceNowConnector",
+        "providerResourceId": "f246dc98-b1f5-4076-a826-349d43ffe1e4"
+    },
+    {
+        "id": "6560a280-2b94-4ec3-ace0-9873ae6d4ee6",
+        "deletedDateTime": null,
+        "capability": "ServiceNowConnectorService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "ServiceNowConnectorService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ITConnection/ServiceNowConnectorService",
+        "providerResourceId": "fd9ef2d2-592b-4d71-b8d1-f5c8723562c5"
+    },
+    {
+        "id": "9194f9cd-fc23-4433-99cb-3dc0ea2be19d",
+        "deletedDateTime": null,
+        "capability": "Service_URL",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "Service_URL",
+        "uri": "https://msud01.manage.microsoft.com/",
+        "providerResourceId": "4ce8423d-f9fa-4834-9b1d-dbab5b891e4c"
+    },
+    {
+        "id": "abbe1e7c-5761-4b5b-88a2-23ceb3dec611",
+        "deletedDateTime": null,
+        "capability": "SideCarGatewayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SideCarGatewayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/SideCar/StatelessSideCarGatewayService",
+        "providerResourceId": "33ef708d-2575-4336-80bf-8739b2fc419d"
+    },
+    {
+        "id": "8ff8a8ee-6a9e-435c-bd27-188dd5a80360",
+        "deletedDateTime": null,
+        "capability": "SideCarGatewayServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SideCarGatewayServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/SideCar/StatelessSideCarGatewayService",
+        "providerResourceId": "de69b19a-0e10-4cc5-804e-c58ee52ce21a"
+    },
+    {
+        "id": "620440c6-6a7d-4c10-87be-6c906b6b8761",
+        "deletedDateTime": null,
+        "capability": "SignOut",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SignOut",
+        "uri": "https://manage.microsoft.com/UISecurityTokenService/StsLogout.aspx?wreply=1&identitypartner=OrgId&ru=https://portal.manage.microsoft.com/ssp.aspx",
+        "providerResourceId": "b6d28d43-7e7e-4e84-aba1-d29e1902552b"
+    },
+    {
+        "id": "40930d73-b904-426c-8b9b-6cb36959978d",
+        "deletedDateTime": null,
+        "capability": "SignalingService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SignalingService",
+        "uri": "https://msud01.manage.microsoft.com/SignalingService/Signal.AsyncHandler",
+        "providerResourceId": "49be223e-a441-465d-bb88-2a7257eeeeda"
+    },
+    {
+        "id": "1e2b822e-6ef2-4e49-83a7-0f7a3a90515a",
+        "deletedDateTime": null,
+        "capability": "SoftwareUpdateGatewayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SoftwareUpdateGatewayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/Updates/SoftwareUpdateService",
+        "providerResourceId": "fee4c131-82ce-4b72-9eb7-451e86c2de9a"
+    },
+    {
+        "id": "bd21cd8e-b508-45b4-8d1b-9f9825b101e2",
+        "deletedDateTime": null,
+        "capability": "SoftwareUpdateGatewayServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SoftwareUpdateGatewayServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/Updates/SoftwareUpdateGatewayService",
+        "providerResourceId": "91797937-1567-47de-85c1-9e628646c0b6"
+    },
+    {
+        "id": "bff2b526-4f26-41c6-a06d-7a903ff11b44",
+        "deletedDateTime": null,
+        "capability": "StatelessAadRelayService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessAadRelayService",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessAadRelayService",
+        "providerResourceId": "9bb1569e-714e-418c-bbf2-5bbe2a2202fd"
+    },
+    {
+        "id": "88cfd6b9-2623-4ea5-9e9b-0c5d843bea54",
+        "deletedDateTime": null,
+        "capability": "StatelessAadRelayServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessAadRelayServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessAadRelayService",
+        "providerResourceId": "8b7ee696-1dd6-4449-8098-ec407397ac1a"
+    },
+    {
+        "id": "13b4b937-1bc2-42d4-bb3f-b5608dc41980",
+        "deletedDateTime": null,
+        "capability": "StatelessAndroidSyncFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessAndroidSyncFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AndroidSync/StatelessAndroidSyncFEService",
+        "providerResourceId": "4ef95124-cff8-4295-afa3-e4bb46ff8d3d"
+    },
+    {
+        "id": "c0ad70a4-bece-4dc9-9625-08ec9c5499d3",
+        "deletedDateTime": null,
+        "capability": "StatelessAndroidSyncFEServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessAndroidSyncFEServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/AndroidSync/StatelessAndroidSyncFEService",
+        "providerResourceId": "114a73a4-7207-4ce2-b758-2ce1d0a44f0b"
+    },
+    {
+        "id": "5f8e7fd4-b555-4112-82bf-f438b794422f",
+        "deletedDateTime": null,
+        "capability": "StatelessChromebookSyncService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessChromebookSyncService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/ChromebookSync/StatelessChromebookSyncService",
+        "providerResourceId": "8b8d18d6-fb84-4772-9bf9-129cbd0ba487"
+    },
+    {
+        "id": "4114e088-015f-443b-bfad-07f8709a8830",
+        "deletedDateTime": null,
+        "capability": "StatelessFERemoteAssistOnboardingService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessFERemoteAssistOnboardingService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RemoteAssistService/StatelessFERemoteAssistOnboardingService",
+        "providerResourceId": "7c5b4c52-1071-415c-9788-6dea959ac746"
+    },
+    {
+        "id": "9e9cd674-ab2e-4314-b672-f194311be342",
+        "deletedDateTime": null,
+        "capability": "StatelessFERemoteAssistOnboardingServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessFERemoteAssistOnboardingServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/RemoteAssistService/StatelessFERemoteAssistOnboardingService",
+        "providerResourceId": "9562d0ca-a8ba-4b77-8a41-c20c2867c471"
+    },
+    {
+        "id": "fd8805b4-637e-4528-94a7-23d5a7177ecf",
+        "deletedDateTime": null,
+        "capability": "StatelessRemoteAssistService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessRemoteAssistService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/RemoteAssistService/StatelessRemoteAssistService",
+        "providerResourceId": "8d89a596-cdfa-4476-acbb-e69ad093ee1a"
+    },
+    {
+        "id": "850108d9-3037-40d3-baf3-5829d6248b08",
+        "deletedDateTime": null,
+        "capability": "StatelessRemoteAssistServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessRemoteAssistServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/RemoteAssistService/StatelessRemoteAssistService",
+        "providerResourceId": "0072ec79-1c57-4cb9-9d1c-c2f7f260d158"
+    },
+    {
+        "id": "aceeb79b-e177-4a53-b254-00bd5d25d962",
+        "deletedDateTime": null,
+        "capability": "StatelessResourceManagementService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessResourceManagementService",
+        "uri": "https://fef.msud01.manage.microsoft.com/RMS/StatelessResourceManagementGatewayService/Gateway/StatelessResourceManagementService",
+        "providerResourceId": "b94f560e-2aa7-407f-8e6f-01971e4b4aaa"
+    },
+    {
+        "id": "6bb013d2-1275-4ce8-9681-b0989c63fcbc",
+        "deletedDateTime": null,
+        "capability": "StatelessTEMApiService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessTEMApiService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/TEMService/StatelessTEMApiService",
+        "providerResourceId": "948c2bc1-52d7-4a4b-af68-a81cb2def48e"
+    },
+    {
+        "id": "3b685126-5d66-451a-a8ee-36a1ef6ab504",
+        "deletedDateTime": null,
+        "capability": "StatelessTEMApiServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessTEMApiServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessTEMApiService",
+        "providerResourceId": "0033d575-7c02-4050-a6c9-fe956884d846"
+    },
+    {
+        "id": "e9d05135-4655-4ee6-884d-0b553b27351c",
+        "deletedDateTime": null,
+        "capability": "StatelessWIPReportFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessWIPReportFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/WIPReportServices/StatelessWIPReportFEService",
+        "providerResourceId": "583b327d-fd35-4663-b6fe-8412c150d582"
+    },
+    {
+        "id": "fe439a59-93e5-48b0-9965-99b9ecd50c54",
+        "deletedDateTime": null,
+        "capability": "StatelessWIPReportFEServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "StatelessWIPReportFEServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/WIPReportServices/StatelessWIPReportFEService",
+        "providerResourceId": "1770bb6f-4eb4-4e0a-99da-64a969ce3afc"
+    },
+    {
+        "id": "589027f9-b408-4706-9d51-ce7c8d0d08b8",
+        "deletedDateTime": null,
+        "capability": "SupportService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SupportService",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessSupportService",
+        "providerResourceId": "db9e92ba-f21c-40f9-a7b3-5a08255b921a"
+    },
+    {
+        "id": "244a8b2c-37db-4f46-bed3-11dd37fd52ed",
+        "deletedDateTime": null,
+        "capability": "SupportServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "SupportServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessSupportService",
+        "providerResourceId": "89e6888e-1f1d-4ba6-9c50-112c31893144"
+    },
+    {
+        "id": "1d547e05-bc16-49e7-bd69-94959ddce6f4",
+        "deletedDateTime": null,
+        "capability": "TEMService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "TEMService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TEMService/StatelessTEMService",
+        "providerResourceId": "7667c928-1705-4d8d-8b14-d0564bb9db68"
+    },
+    {
+        "id": "05dbdd7a-9171-4b9d-9702-3f82ec888396",
+        "deletedDateTime": null,
+        "capability": "TEMServicePreview",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "TEMServicePreview",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessTEMServicePreview",
+        "providerResourceId": "884d2bf2-1190-4169-94f8-785d74722f66"
+    },
+    {
+        "id": "09527703-26a3-4f8e-8858-c694fc95a847",
+        "deletedDateTime": null,
+        "capability": "TEMServicePreviewBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "TEMServicePreviewBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessTEMServicePreview",
+        "providerResourceId": "51f4d007-4dc8-4d9e-85a7-17cad7f3ba16"
+    },
+    {
+        "id": "897a73e5-6767-436a-8d3f-642abc5b10b3",
+        "deletedDateTime": null,
+        "capability": "TaskDownloadService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "TaskDownloadService",
+        "uri": "https://msud01.manage.microsoft.com/RemoteAssistanceService/TaskDownloadService.svc",
+        "providerResourceId": "3521fdd3-c5f1-4df9-9a0a-c7d7e02f8d3a"
+    },
+    {
+        "id": "d24f6e76-6a75-48a9-b780-5802a081285f",
+        "deletedDateTime": null,
+        "capability": "TicketingFEService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "TicketingFEService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/PartnerIntegrations/TicketingFEService",
+        "providerResourceId": "7852851b-7a29-4370-a433-a0d1a9017b51"
+    },
+    {
+        "id": "508b6b2f-5d43-4ec3-b7a8-dd59dacbfe59",
+        "deletedDateTime": null,
+        "capability": "TicketingFEServiceBackup",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "TicketingFEServiceBackup",
+        "uri": "https://fef.msud01.manage.microsoft.com/PartnerIntegrations/TicketingFEService",
+        "providerResourceId": "1ba04cfb-d4dd-406f-aaea-1a766fc4f217"
+    },
+    {
+        "id": "4e403e8a-bcd8-4f73-ad12-97ae0a7b86ee",
+        "deletedDateTime": null,
+        "capability": "TokenRenewalService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "TokenRenewalService",
+        "uri": "https://fef.msud01.manage.microsoft.com/OAuth/StatelessOAuthService/OAuthProxy/",
+        "providerResourceId": "6fef5e1e-6448-4d8e-8ec7-98a97d68b5cc"
+    },
+    {
+        "id": "7859d3ac-fb85-49c3-87a3-5b4b470de506",
+        "deletedDateTime": null,
+        "capability": "TotalNumberOfEndpoints",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "TotalNumberOfEndpoints",
+        "uri": "177",
+        "providerResourceId": "0c101feb-b912-4e7a-9e4b-1d05773cd4d9"
+    },
+    {
+        "id": "3dc582f7-c913-41b1-91f1-9009509c465b",
+        "deletedDateTime": null,
+        "capability": "UnAuthLocationSvc",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "UnAuthLocationSvc",
+        "uri": "https://manage.microsoft.com/UnAuthLocationService/UnAuthLocationService.svc",
+        "providerResourceId": "b63d0f3b-7e26-4b3d-9ca3-9466890a1e95"
+    },
+    {
+        "id": "19f445d0-8226-434c-aba4-d9ec103cd480",
+        "deletedDateTime": null,
+        "capability": "UnlockService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "UnlockService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/AppLifecycle/StatelessUnlockV4Service",
+        "providerResourceId": "cd93f9a4-0b3e-4a6d-88a8-f4daa6ff97ff"
+    },
+    {
+        "id": "b4c8328d-1692-4dee-b64c-e1c68bf5ae92",
+        "deletedDateTime": null,
+        "capability": "UserAuthLocationServiceService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "UserAuthLocationServiceService",
+        "uri": "https://manage.microsoft.com/UserAuthLocationService/UserAuthLocationService.svc",
+        "providerResourceId": "df8303a1-16cf-4a63-be8f-17d4691ec369"
+    },
+    {
+        "id": "f280c5ff-653f-4635-adff-82ff07f1670d",
+        "deletedDateTime": null,
+        "capability": "UserEnrollmentSTS",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "UserEnrollmentSTS",
+        "uri": "https://msud01.manage.microsoft.com/UserEnrollmentSecurityTokenService/IWSTrust.svc",
+        "providerResourceId": "918fc944-39fc-4e1a-bc56-7a23c8106ccc"
+    },
+    {
+        "id": "277417ff-1169-4bf0-b30a-9ba400ed8282",
+        "deletedDateTime": null,
+        "capability": "UserOffboardingService",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "UserOffboardingService",
+        "uri": "https://fef.msud01.manage.microsoft.com/TrafficGateway/TrafficRoutingService/DeviceLifecycle/UserOffboardingService",
+        "providerResourceId": "4dab45a8-0f35-4ed1-8f24-1787b1ad3e70"
+    },
+    {
+        "id": "90b7a305-a475-4e0f-bf31-e02bc6ac59f0",
+        "deletedDateTime": null,
+        "capability": "WebCPAllAppsPage",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "WebCPAllAppsPage",
+        "uri": "https://portal.manage.microsoft.com/apps",
+        "providerResourceId": "362f99a0-8036-45ee-bb5d-f6fd07dd1ce9"
+    },
+    {
+        "id": "a2594e2a-7563-449a-b713-2d20709e9c61",
+        "deletedDateTime": null,
+        "capability": "WebCPAllEbooksPage",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "WebCPAllEbooksPage",
+        "uri": "https://portal.manage.microsoft.com/ebooks",
+        "providerResourceId": "9f9426a4-5388-4ea3-800a-2a527667192e"
+    },
+    {
+        "id": "fcf7d882-daae-41d1-8436-f7bcc13e1ba4",
+        "deletedDateTime": null,
+        "capability": "WebCPRoot",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "WebCPRoot",
+        "uri": "https://portal.manage.microsoft.com/",
+        "providerResourceId": "2f6c1fd5-0598-452e-862c-072f592ba105"
+    },
+    {
+        "id": "41a25532-4e94-410c-a232-1c7416984660",
+        "deletedDateTime": null,
+        "capability": "WebCPiOSCPEnrollmentPage",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "WebCPiOSCPEnrollmentPage",
+        "uri": "https://portal.manage.microsoft.com/enrollment/ios",
+        "providerResourceId": "3149e306-fa52-4e75-9c71-cbad3bcb59f1"
+    },
+    {
+        "id": "4eba3011-0d3f-4178-98ea-3c17e572d7e3",
+        "deletedDateTime": null,
+        "capability": "WindowsEnrollment",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "WindowsEnrollment",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessEnrollmentService/DeviceEnrollment.svc",
+        "providerResourceId": "506451e1-f4d8-4016-af0a-f7e0144babbe"
+    },
+    {
+        "id": "8d533eb4-0e75-425c-8166-8bc4abbe9e2b",
+        "deletedDateTime": null,
+        "capability": "iOSEnrollment",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "iOSEnrollment",
+        "uri": "https://fef.msud01.manage.microsoft.com/StatelessIOSEnrollmentService",
+        "providerResourceId": "b6e25c89-7afb-4492-8c68-293e9915a5db"
+    },
+    {
+        "id": "5197130f-654d-498e-ba91-54d0d4fc919f",
+        "deletedDateTime": null,
+        "capability": "iOSSspEnrollmentPage",
+        "providerId": "0000000a-0000-0000-c000-000000000000",
+        "providerName": "iOSSspEnrollmentPage",
+        "uri": "https://portal.manage.microsoft.com/enrollment/ios",
+        "providerResourceId": "9f010033-5beb-46fd-85a8-3f1b41a9dc69"
+    }
+]

--- a/main.py
+++ b/main.py
@@ -70,8 +70,10 @@ async def main():
         # query_parameters=query_params
     )
     data = await client.service_principals.with_url('https://graph.microsoft.com/beta/servicePrincipals/appId=0000000a-0000-0000-c000-000000000000/endpoints').get(request_configuration=request_config)
+    value_array = data.json().get('value')
+    sorted_value_array = sorted(value_array, key=lambda x: x['capability'])
     with open('Endpoints.json', 'w', encoding='utf-8') as f:
-        json.dump(data.json(), f, ensure_ascii=False, indent=4)
+        json.dump(sorted_value_array, f, ensure_ascii=False, indent=4)
 
     # Defender schemas
     request_config = MicrosoftGraphSecurityRunHuntingQueryRequestBuilder.MicrosoftGraphSecurityRunHuntingQueryRequestBuilderPostRequestConfiguration(


### PR DESCRIPTION
Modify `main.py` to write only the `value` array to `Endpoints.json` and sort its elements alphabetically by their `capability` property.

* Extract the `value` array from the response data.
* Sort the elements in the `value` array alphabetically by their `capability` property.
* Write the sorted `value` array to `Endpoints.json` instead of the entire object.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pl4nty/intune-change-tracking/pull/45?shareId=eba9dc77-5b4a-4a23-be9a-054220e0f71c).